### PR TITLE
Issue 73 solved - QRZ Autocheck only works when adding a new qso

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3422,12 +3422,14 @@ void MainWindow::slotQRZTextChanged(QString _qrz)
     if (!modify)
     {
         searchWidget->setCallToSearch(_qrz);
+
+        if (qrzcomActive && QRZCOMAutoCheckAct->isChecked())
+        {
+            elogQRZcom->checkQRZ(_qrz);
+        }
     }
 
-    if (qrzcomActive && QRZCOMAutoCheckAct->isChecked())
-    {
-        elogQRZcom->checkQRZ(_qrz);
-    }
+
 
     //qrzAutoChanging = false;
     logEvent(Q_FUNC_INFO, "END", logSeverity);


### PR DESCRIPTION
Small change to avoid qrzcom data overwriting data introduced by the user