### PR TITLE
Dx cluster readability

### DIFF
--- a/src/dxcluster.cpp
+++ b/src/dxcluster.cpp
@@ -348,6 +348,8 @@ void DXClusterWidget::slotClusterDataArrived()
     {
         dxClusterString =  tcpSocket->readLine();
         dxClusterString = dxClusterString.trimmed();
+        // Remove BELL-string if exists
+        dxClusterString = dxClusterString.remove("\a");
         saveSpot(dxClusterString);
 
         QStringList tokens = dxClusterString.split(" ", QString::SkipEmptyParts);

--- a/src/dxcluster.cpp
+++ b/src/dxcluster.cpp
@@ -23,6 +23,7 @@ email                : jaime@robles.es
 *    along with KLog.  If not, see <https://www.gnu.org/licenses/>.          *
 *                                                                           *
 *****************************************************************************/
+#include <QFont>
 #include "dxcluster.h"
 
 DXClusterWidget::DXClusterWidget(DataProxy_SQLite *dp, QWidget *parent)
@@ -447,6 +448,7 @@ void DXClusterWidget::slotClusterDataArrived()
 
         QListWidgetItem *item = new QListWidgetItem();
         item->setForeground(QBrush(dxSpotColor));
+        item->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
         item->setText(dxClusterString);
 
 /*


### PR DESCRIPTION
Hello,

I have prepared 2 commits, which in my opinion will improve a readability of the DX Cluster window.

1) Using a system fixed type font improve formatting of DX Cluster message - unfortunately, tested only under Linux
2) Removing bell characters from DX Cluster messages causes that DX spot has only one row without an unexpected characters