### PR TITLE
Removal DX Cluster unexpected disconnection

### DIFF
--- a/src/dxcluster.cpp
+++ b/src/dxcluster.cpp
@@ -570,22 +570,7 @@ void DXClusterWidget::slotClusterClearLineInput()
 {
        //qDebug() << "DXClusterWidget::slotClusterClearLineInput" << endl;
 
-    if ( ((inputCommand->text()).length()) <= 0 )
-    {
-        if ( dxClusterConnected )
-        {
-            QTextStream os(tcpSocket);
-            os << "bye\n";
-        }
-        else
-        {
-        }
-    }
-    else
-    {
-        inputCommand->clear();
-    }
-
+    inputCommand->clear();
 }
 
 void DXClusterWidget::slotClusterInputTextChanged()

--- a/src/dxcluster.cpp
+++ b/src/dxcluster.cpp
@@ -558,8 +558,6 @@ void DXClusterWidget::slotClusterSendToServer()
     if ( inputCommand ->text().length() < 1 )
     {
            //qDebug() << "DXClusterWidget::slotClusterSendToServer() - Vacio..." << endl;
-        QTextStream os(tcpSocket);
-        os << "bye\n";
         return;
     }
     //  write to the server


### PR DESCRIPTION
Following commits remove an unexpected DXC disconnection in following cases

1) when an empty DXC command is sent by pressing ENTER
2) when Clear button is pressed and DXC command field is empty