### PR TITLE
Fixed issue 194: maximized main window after setup

### DIFF
--- a/src/setupdialog.cpp
+++ b/src/setupdialog.cpp
@@ -165,6 +165,8 @@ SetupDialog::SetupDialog(DataProxy_SQLite *dp, const QString &_configFile, const
     version = _softwareVersion;
     pageRequested = _page;
     int logsPageTabN=-1;
+    parent_widget = parent;
+
     //qDebug() << "SetupDialog::SetupDialog 01" << endl;
 
     locator = new Locator();
@@ -788,10 +790,14 @@ void SetupDialog::slotOkButtonClicked()
         //WSJTX
 
         //Windows Size
-        if (windowSize.length()>0)
+        if ( parent_widget != nullptr )
         {
-            stream << "MainWindowSize=" << windowSize << ";" <<  endl;
+           stream << "MainWindowSize=" << QString::number(parent_widget->size().width())
+                                       << "x"
+                                       << QString::number(parent_widget->size().height())
+                                       << ";" << endl;
         }
+
         if (latestBackup.length()>0)
         {
             stream << "LatestBackup=" << latestBackup << ";" << endl;

--- a/src/setupdialog.h
+++ b/src/setupdialog.h
@@ -147,6 +147,8 @@ private:
 
     Utilities *util;
     QString windowSize;
+    QWidget *parent_widget;
+
     QString latestBackup;
 
     int constrid; // Just an id for the constructor to check who is being executed at one specific time


### PR DESCRIPTION
Setup Dialog saves a current size of the main window to configuration file
when Setup Dialog OK button is pressed.