### PR TITLE
Wrong text at OKButton in MainQSOEntryWidget

### DIFF
--- a/src/mainqsoentrywidget.cpp
+++ b/src/mainqsoentrywidget.cpp
@@ -396,7 +396,7 @@ void MainQSOEntryWidget::clear()
 
     //qDebug() << Q_FUNC_INFO << endl;
 
-    cleaning = true;
+    //cleaning = true;
 
     OKButton->setText(tr("&Add"));
     qrzLineEdit->clear();

--- a/src/mainqsoentrywidget.cpp
+++ b/src/mainqsoentrywidget.cpp
@@ -795,10 +795,11 @@ void MainQSOEntryWidget::setModify(const bool _modify)
 {
     emit debugLog(Q_FUNC_INFO, "Start", Debug);
     modify = _modify;
-    realtimeCheckBox->setChecked (false);
+
     if (modify)
     {
         OKButton->setText(tr("&Modify"));
+        realtimeCheckBox->setChecked (false);
     }
     else
     {

--- a/src/mainqsoentrywidget.cpp
+++ b/src/mainqsoentrywidget.cpp
@@ -396,13 +396,13 @@ void MainQSOEntryWidget::clear()
 
     //qDebug() << Q_FUNC_INFO << endl;
 
-    cleaning = true;
+    //cleaning = true;
 
     OKButton->setText(tr("&Add"));
     qrzLineEdit->clear();
     qrzLineEdit->setFocus(Qt::OtherFocusReason);
 
-    cleaning = false;
+    //cleaning = false;
     emit debugLog(Q_FUNC_INFO, "END", Debug);
 }
 
@@ -436,7 +436,8 @@ void MainQSOEntryWidget::setInitialData()
     // //qDebug()ime = true;
 
     timer->start(1000);
-   emit debugLog(Q_FUNC_INFO, "END", Debug);
+
+    emit debugLog(Q_FUNC_INFO, "END", Debug);
      //qDebug()<< "MainQSOEntryWidget::setInitialData-END" << endl;
 
 }
@@ -804,6 +805,11 @@ void MainQSOEntryWidget::setModify(const bool _modify)
         OKButton->setText(tr("&Add"));
     }
     emit debugLog(Q_FUNC_INFO, "END", Debug);
+}
+
+bool MainQSOEntryWidget::getModifying()
+{
+    return modify;
 }
 
 void MainQSOEntryWidget::slotUpdateTime()

--- a/src/mainqsoentrywidget.h
+++ b/src/mainqsoentrywidget.h
@@ -64,6 +64,7 @@ public:
     void toggleRealTime();
     void setUTC(const bool _utc);
     void setModify(const bool _modify);
+    bool getModifying();
     void setUpAndRunning(const bool _u);
     void selectDefaultBand(const bool _init = false);
     void selectDefaultMode(const bool _init = false);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -8366,6 +8366,8 @@ void MainWindow::backupCurrentQSO()
     qDebug() << Q_FUNC_INFO;
     qso->clear ();
     qso->setBackup (true);
+    qso->setModifying (mainQSOEntryWidget->getModifying());
+
     // MainQSOEntryWidget
     qso->setCall (mainQSOEntryWidget->getQrz ());
     qso->setBand (mainQSOEntryWidget->getBand ());
@@ -8438,7 +8440,10 @@ void MainWindow::restoreCurrentQSO(const bool restoreConfig)
     // MainQSOEntryWidget
     //qDebug() << Q_FUNC_INFO << ": " << util->boolToQString (restoreConfig);
     clearUIDX ();
-
+    if (qso->getModifying())
+    {
+        mainQSOEntryWidget->setModify(true);
+    }
     mainQSOEntryWidget->setQRZ (qso->getCall ());
     mainQSOEntryWidget->setBand (qso->getBand ());
     mainQSOEntryWidget->setMode (qso->getMode ());

--- a/src/qso.cpp
+++ b/src/qso.cpp
@@ -99,6 +99,8 @@ void QSO::clear()
     keepMyData = false;
     keepOther = false;
     keepSat = false;
+    modifying = false;
+
 }
 
 void QSO::setBackup(const bool _rt)
@@ -109,6 +111,16 @@ void QSO::setBackup(const bool _rt)
 bool QSO::getBackup()
 {
     return backup;
+}
+
+void QSO::setModifying(const bool _mod)
+{
+    modifying = _mod;
+}
+
+bool QSO::getModifying()
+{
+    return modifying;
 }
 
 bool QSO::setQSOid(const int _i)

--- a/src/qso.h
+++ b/src/qso.h
@@ -43,6 +43,9 @@ public:
     void setBackup(const bool _rt);
     bool getBackup();
 
+    void setModifying(const bool _mod);
+    bool getModifying();
+
     bool setData(const QString &_adifPair);
     void clear();
     bool isValid();
@@ -214,7 +217,7 @@ private:
     QString QRZCom_status;
     QDate QRZComDate;
     QString comment;
-    bool keepComment, keepOther, keepMyData, keepSat;
+    bool keepComment, keepOther, keepMyData, keepSat, modifying;
 
     QString iota;
 


### PR DESCRIPTION
OKButton shows "Add" text instead of "Modify" when coming back from Setup editing a QSO. 

Now, qso class saves if QSO has been modified or not when a QSO backup is made.