### PR TITLE
Inclusive search and submodes in LoTW download

### DIFF
--- a/src/dataproxy_sqlite.cpp
+++ b/src/dataproxy_sqlite.cpp
@@ -3104,7 +3104,7 @@ QList<int> DataProxy_SQLite::isThisQSODuplicated(const QString &_callingFunc, co
     // We will match +-15min
 
 
-    queryString = QString("SELECT id, qso_date FROM log WHERE call='%1' AND bandid='%2' AND modeid='%3' AND qso_date>'%4' AND qso_date<'%5'").arg(_qrz).arg(_band).arg(_mode).arg(initTime).arg(endTime);
+    queryString = QString("SELECT id, qso_date FROM log WHERE call='%1' AND bandid='%2' AND modeid='%3' AND qso_date>='%4' AND qso_date<='%5'").arg(_qrz).arg(_band).arg(_mode).arg(initTime).arg(endTime);
 
     bool sqlOK = query.exec(queryString);
 

--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -1021,7 +1021,13 @@ QList<int> FileManager::adifLoTWReadLog2(const QString& fileName, const int logN
                     }
                     QList<int> dupeQsos;
                     dupeQsos.clear();
-                    dupeQsos << dataProxy->isThisQSODuplicated(Q_FUNC_INFO, qso.getCall(), qso.getDateTimeOn(), dataProxy->getIdFromBandName(qso.getBand()), dataProxy->getIdFromModeName(qso.getMode()), duplicatedQSOSlotInSecs);
+                    int mode;
+                    if (qso.getSubmode().isEmpty()) {
+                        mode = dataProxy->getIdFromModeName(qso.getMode());
+                    } else {
+                        mode = dataProxy->getSubModeIdFromSubMode(qso.getSubmode());
+                    }
+                    dupeQsos << dataProxy->isThisQSODuplicated(Q_FUNC_INFO, qso.getCall(), qso.getDateTimeOn(), dataProxy->getIdFromBandName(qso.getBand()), mode, duplicatedQSOSlotInSecs);
 
                     if ((dupeQsos.length()<1) && (!askedToAddNewQSOs) )
                     {


### PR DESCRIPTION
I'm not sure if it is an expected condition (I didn't set it, so it may be another issue), but my duplicatedQSOSlotInSecs is 0, so an impossible query was generated (e.g. qso_date > 2023-05-06 00:17:00 AND qso_date < 2023-05-06 00:17:00). To fix this, I made both comparisons inclusive.

adifLoTWReadLog2 was completely ignoring submode (so FT4 appeared as MFSK (modeid 76 rather than 26), for example), so I added a check for it and use it when present.