### PR TITLE
Fix iota being incorrectly saved as my_iota

### DIFF
--- a/src/qso.cpp
+++ b/src/qso.cpp
@@ -2094,7 +2094,7 @@ bool QSO::setMyIOTA(const QString &_c)
 
 QString QSO::getMyIOTA()
 {
-    return iota;
+    return my_iota;
 }
 
 bool QSO::setMyIotaID(const int _i)


### PR DESCRIPTION
Currently, if IOTA index is not empty, it is stored in SQLite database as "iota" and "my_iota". As a consequence, the incorrect my_iota appears in the exported ADIF file for example. This fix rectifies the bug.