### PR TITLE
Slightly improve frequency handling

### DIFF
--- a/src/inputwidgets/mainwindowinputqso.cpp
+++ b/src/inputwidgets/mainwindowinputqso.cpp
@@ -80,13 +80,15 @@ void MainWindowInputQSO::createUI()
     rxPowerSpinBox->setMaximum(9999);
     rxPowerSpinBox->setSuffix(" " + tr("Watts"));
 
-    txFreqSpinBox->setDecimals(3);
+    txFreqSpinBox->setDecimals(6);
     txFreqSpinBox->setMaximum(99999);
     txFreqSpinBox->setSuffix(" " + tr("MHz"));
+    txFreqSpinBox->setSingleStep(0.001);
 
-    rxFreqSpinBox->setDecimals(3);
+    rxFreqSpinBox->setDecimals(6);
     rxFreqSpinBox->setMaximum(99999);
     rxFreqSpinBox->setSuffix(" " + tr("MHz"));
+    rxFreqSpinBox->setSingleStep(0.001);
 
     splitCheckBox->setText(tr("Split", "Translator: Split is a common hamradio term. Do not translate unless you are sure."));
     splitCheckBox->setChecked(false);

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -1223,7 +1223,7 @@ bool Utilities::isSameFreq(const double fr1, const double fr2)
 {
     //qDebug() << QString("%1-%2").arg(Q_FUNC_INFO).arg(parentName) << ": " << QString::number(fr1) << "/" << QString::number(fr2) << " = " << QString::number(fabs(fr1 - fr2)) ;
 
-    if (fabs(fr1 - fr2) < 0.001)
+    if (fabs(fr1 - fr2) < 0.00001) // 10 Hz
     {
         //qDebug() << QString("%1-%2").arg(Q_FUNC_INFO).arg(parentName) << " - true" ;
         return true;


### PR DESCRIPTION
Set QSO frequency input spinbox precision to 1 Hz to allow manual entry.
Change QSO::isSameFreq() comparison to 10 Hz so tuning up or down 100 Hz is detected as freq change.

This should allow better frequency inputs for now.