### PR TITLE
Fix log widget showing no QSOs

### DIFF
--- a/src/logmodel.cpp
+++ b/src/logmodel.cpp
@@ -127,9 +127,7 @@ This should be coherent with the logview
     //QString stringQuery = QString("lognumber='%1'").arg(_i);
     // qSqlQuery query(stringQuery);
 
-    QString stringQuery = QString(
-        "id IN (SELECT id FROM log WHERE lognumber='%1' ORDER BY date DESC, time DESC LIMIT 500)"
-        ).arg(_i);
+    QString stringQuery = QString("lognumber='%1'").arg(_i);
     setFilter(stringQuery);
 
 

--- a/src/logwindow.cpp
+++ b/src/logwindow.cpp
@@ -173,7 +173,6 @@ void LogWindow::createlogPanel(const int _currentLog)
     logView->sortByColumn(1, Qt::DescendingOrder);
 
     retoreColumsOrder();
-    retoreColumsOrder();
     //qDebug() << Q_FUNC_INFO << " - END";
 }
 


### PR DESCRIPTION
The SQL filter in LogModel::createlogModel() used a subquery `id IN (SELECT id FROM log WHERE lognumber=... LIMIT 500)`. When QSqlRelationalTableModel executes this with LEFT JOINs to the band, mode, and entity tables (each having their own `id` column), the bare `id` reference in the WHERE clause is ambiguous, causing the query to fail silently and return zero rows.

Fix: revert the filter to the simple `lognumber='%1'` form (matching what loadAllQSOs() already uses) so all QSOs are shown correctly.

Also remove the accidental duplicate retoreColumsOrder() call introduced in the same commit.

https://claude.ai/code/session_018LtHi6w7yVuJ7Z8U5Yxk4p