### PR TITLE
Add user prompt for Hamlib connection failure at startup

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3481,11 +3481,27 @@ void MainWindow::slotInitHamlib()
     if (!hamlibActive)
     {
         logEvent(Q_FUNC_INFO, "HamLib connection failed on startup", Warning);
-        QMessageBox::warning(this,
-            tr("Radio connection failed"),
-            tr("KLog could not connect to the radio at startup.\n\n"
-            "Please check the radio is on and the port settings are correct.\n"
-            "You can reconfigure and test the connection in Setup → Hamlib."));
+
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Warning);
+        msgBox.setWindowTitle(tr("Radio connection failed"));
+        msgBox.setText(tr("KLog could not connect to the radio at startup."));
+        msgBox.setInformativeText(tr("Please check the radio is on and the port settings are correct.\n"
+                                     "You can reconfigure and test the connection in Setup → Hamlib.\n\n"
+                                     "Do you want KLog to try to connect automatically on next startup?"));
+        msgBox.addButton(tr("Yes, reconnect on startup"), QMessageBox::YesRole);
+        QPushButton *noButton = msgBox.addButton(tr("No, disable radio connection"), QMessageBox::NoRole);
+        msgBox.exec();
+
+        if (msgBox.clickedButton() == noButton)
+        {
+            QSettings settings(util->getCfgFile(), QSettings::IniFormat);
+            settings.beginGroup("HamLib");
+            settings.setValue("HamLibActive", false);
+            settings.endGroup();
+            settings.sync();
+            logEvent(Q_FUNC_INFO, "HamLibActive set to false by user after startup failure", Info);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Enhanced the Hamlib connection failure dialog at startup to provide users with an option to disable automatic radio connection attempts, rather than just displaying a static warning message.

## Key Changes
- Replaced simple `QMessageBox::warning()` call with a custom `QMessageBox` that includes action buttons
- Added two user options:
  - "Yes, reconnect on startup" (default behavior)
  - "No, disable radio connection" (persists user preference)
- Implemented settings persistence: when users select "No", the `HamLibActive` setting is disabled in the configuration file
- Added appropriate logging when the user disables radio connection after a startup failure
- Improved message clarity by separating the main message from detailed instructions using `setInformativeText()`

## Implementation Details
- The dialog now uses `QMessageBox::exec()` to wait for user interaction
- User choice is tracked by comparing the clicked button against the stored `noButton` pointer
- Settings are written to the HamLib configuration group and synced immediately to ensure persistence
- The change maintains backward compatibility - users who don't interact with the dialog experience the same behavior as before

https://claude.ai/code/session_018AHfn759srN3vnhgeD7kFb