### PR TITLE
Fix low contrast tooltips in dark mode

### DIFF
--- a/src/Changelog
+++ b/src/Changelog
@@ -35,6 +35,7 @@ TBD
 - Bugfix: Map Filter is not properly filtering (Closes #827)
 - Bugfix: Primary subdivisions table in DB allowed duplicated entries.
 - Bugfix: SAT mode saved as SAT when no SAT QSO is done (Closes #857)
+- Bugfix: Low contrast in tooltips when using dark mode or system dark themes (Closes #642)
 
 Feb 2026 - 2.4.3
 - Enhancement: Add the FT2 submode

--- a/src/setuppages/setuppagecolors.cpp
+++ b/src/setuppages/setuppagecolors.cpp
@@ -297,9 +297,10 @@ void SetupPageColors::setDarkMode(const bool _d)
         p.setColor(QPalette::ButtonText, Qt::white);
         p.setColor(QPalette::WindowText, Qt::white);
         p.setColor(QPalette::Base, QColor(100,100,100));
-        p.setColor(QPalette::ToolTipBase, Qt::white);
-        p.setColor(QPalette::ToolTipText, Qt::black);
+        p.setColor(QPalette::ToolTipBase, QColor(53,53,53));
+        p.setColor(QPalette::ToolTipText, Qt::white);
         qApp->setPalette(p);
+        qApp->setStyleSheet("QToolTip { color: white; background-color: #353535; border: 1px solid #aaaaaa; }");
         darkModeButton->setText(tr("Light Mode"));
         //darkMode = true;
     }
@@ -319,6 +320,7 @@ void SetupPageColors::setDarkMode(const bool _d)
         p.setColor(QPalette::ToolTipBase, Qt::white);
         p.setColor(QPalette::ToolTipText, Qt::black);
         qApp->setPalette(p);
+        qApp->setStyleSheet("QToolTip { color: black; background-color: white; border: 1px solid #aaaaaa; }");
         darkModeButton->setText(tr("Dark Mode"));
         //darkMode = false;
     }


### PR DESCRIPTION
## Summary
Improves tooltip visibility in dark mode and light mode by adjusting both palette colors and stylesheet properties to ensure adequate contrast.

## Changes
- **Dark mode tooltips**: Changed tooltip background from white to dark gray (#353535) and text color from black to white for better contrast against dark backgrounds
- **Light mode tooltips**: Added explicit stylesheet to ensure consistent tooltip styling with black text on white background
- **Stylesheet application**: Added QToolTip stylesheet rules for both dark and light modes to explicitly set colors and borders, ensuring tooltips render correctly across different system themes

## Implementation Details
- Updated `QPalette::ToolTipBase` and `QPalette::ToolTipText` color assignments in the `setDarkMode()` function
- Applied `qApp->setStyleSheet()` for both dark and light mode branches to override default tooltip styling
- Added a 1px solid gray border (#aaaaaa) to tooltips for better definition in both modes
- This addresses issue #642 regarding low contrast tooltips when using dark mode or system dark themes

https://claude.ai/code/session_017cuRtXehKU3qQRG2BZSKhV