### PR TITLE
Remove dark mode functionality and simplify palette management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ tests/tst_adif/uic_wrapper.sh
 tests/tst_database/moc_adif.cpp
 tests/tst_database/moc_database.cpp
 tests/tst_database/moc_dataproxy_sqlite.cpp
-tests/tst_database/moc_db_adif_primary_subdvisions_data.cpp
+tests/tst_database/moc_db_adif_primary_subdivisions_data.cpp
 tests/tst_database/moc_qso.cpp
 tests/tst_database/moc_queryexecutor.cpp
 tests/tst_database/moc_utilities.cpp
@@ -66,7 +66,7 @@ tests/tst_database/uic_wrapper.sh
 tests/tst_dataproxy/moc_adif.cpp
 tests/tst_dataproxy/moc_database.cpp
 tests/tst_dataproxy/moc_dataproxy_sqlite.cpp
-tests/tst_dataproxy/moc_db_adif_primary_subdvisions_data.cpp
+tests/tst_dataproxy/moc_db_adif_primary_subdivisions_data.cpp
 tests/tst_dataproxy/moc_qso.cpp
 tests/tst_dataproxy/moc_queryexecutor.cpp
 tests/tst_dataproxy/moc_utilities.cpp
@@ -98,7 +98,7 @@ tests/tst_main/uic_wrapper.sh
 tests/tst_mainqsoentrywidget/moc_adif.cpp
 tests/tst_mainqsoentrywidget/moc_database.cpp
 tests/tst_mainqsoentrywidget/moc_dataproxy_sqlite.cpp
-tests/tst_mainqsoentrywidget/moc_db_adif_primary_subdvisions_data.cpp
+tests/tst_mainqsoentrywidget/moc_db_adif_primary_subdivisions_data.cpp
 tests/tst_mainqsoentrywidget/moc_mainqsoentrywidget.cpp
 tests/tst_mainqsoentrywidget/moc_qso.cpp
 tests/tst_mainqsoentrywidget/moc_queryexecutor.cpp
@@ -116,7 +116,7 @@ tests/tst_mainwindow/uic_wrapper.sh
 tests/tst_mainwindowinputqso/moc_adif.cpp
 tests/tst_mainwindowinputqso/moc_database.cpp
 tests/tst_mainwindowinputqso/moc_dataproxy_sqlite.cpp
-tests/tst_mainwindowinputqso/moc_db_adif_primary_subdvisions_data.cpp
+tests/tst_mainwindowinputqso/moc_db_adif_primary_subdivisions_data.cpp
 tests/tst_mainwindowinputqso/moc_mainwindowinputqso.cpp
 tests/tst_mainwindowinputqso/moc_qso.cpp
 tests/tst_mainwindowinputqso/moc_queryexecutor.cpp
@@ -129,7 +129,7 @@ tests/tst_mainwindowinputqso/uic_wrapper.sh
 tests/tst_mainwindowsattab/moc_adif.cpp
 tests/tst_mainwindowsattab/moc_database.cpp
 tests/tst_mainwindowsattab/moc_dataproxy_sqlite.cpp
-tests/tst_mainwindowsattab/moc_db_adif_primary_subdvisions_data.cpp
+tests/tst_mainwindowsattab/moc_db_adif_primary_subdivisions_data.cpp
 tests/tst_mainwindowsattab/moc_mainwindowsattab.cpp
 tests/tst_mainwindowsattab/moc_qso.cpp
 tests/tst_mainwindowsattab/moc_queryexecutor.cpp
@@ -162,7 +162,7 @@ tests/tst_setuphamlibserialwidget/uic_wrapper.sh
 tests/tst_setuppageelog/moc_adif.cpp
 tests/tst_setuppageelog/moc_database.cpp
 tests/tst_setuppageelog/moc_dataproxy_sqlite.cpp
-tests/tst_setuppageelog/moc_db_adif_primary_subdvisions_data.cpp
+tests/tst_setuppageelog/moc_db_adif_primary_subdivisions_data.cpp
 tests/tst_setuppageelog/moc_qso.cpp
 tests/tst_setuppageelog/moc_queryexecutor.cpp
 tests/tst_setuppageelog/moc_setuppageelog.cpp
@@ -175,7 +175,7 @@ tests/tst_setuppageelog/uic_wrapper.sh
 tests/tst_utilities/moc_adif.cpp
 tests/tst_utilities/moc_database.cpp
 tests/tst_utilities/moc_dataproxy_sqlite.cpp
-tests/tst_utilities/moc_db_adif_primary_subdvisions_data.cpp
+tests/tst_utilities/moc_db_adif_primary_subdivisions_data.cpp
 tests/tst_utilities/moc_qso.cpp
 tests/tst_utilities/moc_queryexecutor.cpp
 tests/tst_utilities/moc_utilities.cpp
@@ -196,7 +196,7 @@ tests/tst_wizard/uic_wrapper.sh
 tests/tst_world/moc_adif.cpp
 tests/tst_world/moc_database.cpp
 tests/tst_world/moc_dataproxy_sqlite.cpp
-tests/tst_world/moc_db_adif_primary_subdvisions_data.cpp
+tests/tst_world/moc_db_adif_primary_subdivisions_data.cpp
 tests/tst_world/moc_qso.cpp
 tests/tst_world/moc_queryexecutor.cpp
 tests/tst_world/moc_utilities.cpp
@@ -209,7 +209,7 @@ tests/tst_world/uic_wrapper.sh
 tests/tst_mainwindowinputothers/moc_adif.cpp
 tests/tst_mainwindowinputothers/moc_database.cpp
 tests/tst_mainwindowinputothers/moc_dataproxy_sqlite.cpp
-tests/tst_mainwindowinputothers/moc_db_adif_primary_subdvisions_data.cpp
+tests/tst_mainwindowinputothers/moc_db_adif_primary_subdivisions_data.cpp
 tests/tst_mainwindowinputothers/moc_mainwindowinputothers.cpp
 tests/tst_mainwindowinputothers/moc_predefs.h
 tests/tst_mainwindowinputothers/moc_qso.cpp
@@ -263,7 +263,7 @@ tests/tst_logwindow/moc_awards.cpp
 tests/tst_logwindow/moc_callsign.cpp
 tests/tst_logwindow/moc_database.cpp
 tests/tst_logwindow/moc_dataproxy_sqlite.cpp
-tests/tst_logwindow/moc_db_adif_primary_subdvisions_data.cpp
+tests/tst_logwindow/moc_db_adif_primary_subdivisions_data.cpp
 tests/tst_logwindow/moc_filemanager.cpp
 tests/tst_logwindow/moc_frequency.cpp
 tests/tst_logwindow/moc_logmodel.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,7 +29,7 @@ set(KLOG_SOURCES
    callsign.cpp
    database/database.cpp
    database/datacache.cpp
-   database/db_adif_primary_subdvisions_data.cpp
+   database/db_adif_primary_subdivisions_data.cpp
    database/queryexecutor.cpp
    dataproxy_sqlite.cpp
    downloadcty.cpp
@@ -128,7 +128,7 @@ set(KLOG_HEADERS
    callsign.h
    database/database.h
    database/datacache.h
-   database/db_adif_primary_subdvisions_data.h
+   database/db_adif_primary_subdivisions_data.h
    database/queryexecutor.h
    dataproxy_sqlite.h
    downloadcty.h

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -26,7 +26,7 @@
 
 #include "database.h"
 #include "../adif.h"
-#include "db_adif_primary_subdvisions_data.h"
+#include "db_adif_primary_subdivisions_data.h"
 //#include <qDebug>
 
 DataBase::DataBase(const QString &_parentClass, const QString &_DBName)

--- a/src/database/db_adif_primary_subdivisions_data.cpp
+++ b/src/database/db_adif_primary_subdivisions_data.cpp
@@ -1,4 +1,4 @@
-#include "db_adif_primary_subdvisions_data.h"
+#include "db_adif_primary_subdivisions_data.h"
 
 DB_ADIF_Primary_Subdvisions_data::DB_ADIF_Primary_Subdvisions_data(const QString &_parentClass)
 {

--- a/src/database/db_adif_primary_subdivisions_data.h
+++ b/src/database/db_adif_primary_subdivisions_data.h
@@ -1,5 +1,5 @@
-#ifndef KLOG_DATABASE_DB_ADIF_PRIMARY_SUBDVISIONS_DATA_H
-#define KLOG_DATABASE_DB_ADIF_PRIMARY_SUBDVISIONS_DATA_H
+#ifndef KLOG_DATABASE_DB_ADIF_PRIMARY_SUBDIVISIONS_DATA_H
+#define KLOG_DATABASE_DB_ADIF_PRIMARY_SUBDIVISIONS_DATA_H
 /***************************************************************************
                           db_adif_primary_subdivisions_data.h  -  description
                              -------------------
@@ -70,4 +70,4 @@ private:
     bool add_Japan_339();   // Adds the data for Japan
 };
 
-#endif // DB_ADIF_PRIMARY_SUBDVISIONS_DATA_H
+#endif // DB_ADIF_PRIMARY_SUBDIVISIONS_DATA_H

--- a/src/inputwidgets/mainwindowinputothers.cpp
+++ b/src/inputwidgets/mainwindowinputothers.cpp
@@ -138,11 +138,7 @@ void MainWindowInputOthers::createUI()
     sig         = QString();
     sig_info    = QString();
     wwff_ref    = QString();
-    darkMode    = false;
-
     palRed.setColor(QPalette::Text, Qt::red);
-    palBlack.setColor(QPalette::Text, Qt::black);
-    palWhite.setColor(QPalette::Text, Qt::white);
 
     QLabel *entityPrimLabel = new QLabel(tr("Primary Div"));
     QLabel *entitySecLabel  = new QLabel(tr("Secondary Div"));
@@ -221,7 +217,6 @@ void MainWindowInputOthers::createUI()
     iotaContinentComboBox->addItems(dataProxy->getContinentShortNames());
     iotaNumberLineEdit->setInputMask("000");
     iotaNumberLineEdit->setText("000");
-    readDarkMode();
     logEvent (Q_FUNC_INFO, "END", Debug);
 
     //qDebug() << Q_FUNC_INFO << ": (" << QString::number(this->size ().width ()) << "/" << QString::number(this->size ().height ()) << ")" ;
@@ -374,20 +369,9 @@ void MainWindowInputOthers::setPaletteIOTA(const bool _ok)
 {
     //qDebug() << Q_FUNC_INFO << " - Start";
     if (_ok)
-    {
-        if (darkMode)
-        {
-            iotaNumberLineEdit->setPalette (palWhite);
-        }
-        else
-        {
-            iotaNumberLineEdit->setPalette (palBlack);
-        }
-    }
+        iotaNumberLineEdit->unsetPalette();
     else
-    {
         iotaNumberLineEdit->setPalette (palRed);
-    }
 }
 
 
@@ -398,26 +382,6 @@ void MainWindowInputOthers::clearIOTA()
     iotaNumberLineEdit->setText("000");
     logEvent (Q_FUNC_INFO, "END", Debug);
     setPaletteIOTA(true);    //To avoid that 000 is considered wrong
-}
-
-void MainWindowInputOthers::setDarkMode (const bool _dm)
-{
-    darkMode = _dm;
-
-    if (darkMode)
-    {
-       //qDebug() << Q_FUNC_INFO << " - True";
-        iotaNumberLineEdit->setPalette(palWhite);
-        userDefinedADIFValueLineEdit->setPalette(palWhite);
-        iotaNumberLineEdit->setPalette(palWhite);
-    }
-    else
-    {
-       //qDebug() << Q_FUNC_INFO << " - False";
-        iotaNumberLineEdit->setPalette(palBlack);
-        userDefinedADIFValueLineEdit->setPalette(palBlack);
-        iotaNumberLineEdit->setPalette(palBlack);
-    }
 }
 
 bool MainWindowInputOthers::isIOTAModified()
@@ -444,14 +408,7 @@ void MainWindowInputOthers::setIOTA(const QString &_qs)
           //qDebug() << Q_FUNC_INFO << ": IOTA " << _qs;
         iotaContinentComboBox->setCurrentIndex( iotaContinentComboBox->findText(values.at(0) ) );
         iotaNumberLineEdit->setText(values.at(1));
-        if (darkMode)
-        {
-            iotaNumberLineEdit->setPalette(palWhite);
-        }
-        else
-        {
-            iotaNumberLineEdit->setPalette(palBlack);
-        }
+        iotaNumberLineEdit->unsetPalette();
     }
     logEvent (Q_FUNC_INFO, "END", Debug);
 }
@@ -1021,14 +978,7 @@ QString MainWindowInputOthers::getVUCCGrids()
 void MainWindowInputOthers::setColorsForUserDefinedADIFValueLineEdit()
 {
     logEvent (Q_FUNC_INFO, "Start", Debug);
-    if (darkMode)
-    {
-        userDefinedADIFValueLineEdit->setPalette(palWhite);
-    }
-    else
-    {
-        userDefinedADIFValueLineEdit->setPalette(palBlack);
-    }
+    userDefinedADIFValueLineEdit->unsetPalette();
     logEvent (Q_FUNC_INFO, "END", Debug);
 }
 
@@ -1152,15 +1102,6 @@ void MainWindowInputOthers::slotEntityNameComboBoxChanged()
     //entityPrimDivComboBox->clear();
     entityPrimDivComboBox->addItem("00-" + tr("None Identified") + " (000)");
 }
-
-void MainWindowInputOthers::readDarkMode()
-{
-    QSettings settings(util->getCfgFile (), QSettings::IniFormat);
-    settings.beginGroup ("Colors");
-    setDarkMode(settings.value("DarkMode", false).toBool ());
-    settings.endGroup ();
-}
-
 
 void MainWindowInputOthers::setLogLevel (const DebugLogLevel _l)
 {

--- a/src/inputwidgets/mainwindowinputothers.h
+++ b/src/inputwidgets/mainwindowinputothers.h
@@ -44,7 +44,6 @@ class MainWindowInputOthers : public QWidget
 public:
     MainWindowInputOthers(DataProxy_SQLite *dp, World *injectedWorld, QWidget *parent = nullptr);
     ~MainWindowInputOthers();
-    void setDarkMode (const bool _dm);
     QSO getQSOData(QSO _qso);
     void setQSOData(const QSO &_qso);
     void setEntitiesList();
@@ -121,15 +120,12 @@ private:
     void setPaletteIOTA(const bool _ok);
 
     void updatePrimarySubdivisionsComboBox(QList<PrimarySubdivision> _subdivisions);
-    //bool getDarkMode();
-    void readDarkMode();
     void logEvent(const QString &_func, const QString &_msg, DebugLogLevel _level);
 
 
     Utilities *util;
     DataProxy_SQLite *dataProxy;
     World *world;
-    bool darkMode;
 
     QStringList  propModeList; // entitiesList,
     // qLabel *entityPrimLabel, *entitySecLabel, *iotaAwardLabel, *entityNameLabel, *propModeLabel;
@@ -137,7 +133,7 @@ private:
     QLineEdit *iotaNumberLineEdit;
     QCheckBox *keepPropCheckBox, *showAllCheckBox;
 
-    QPalette palRed, palBlack, palWhite;
+    QPalette palRed;
     bool autoUpdating;
 
     QComboBox *userDefinedADIFComboBox;

--- a/src/inputwidgets/mainwindowinputqso.cpp
+++ b/src/inputwidgets/mainwindowinputqso.cpp
@@ -282,8 +282,6 @@ void MainWindowInputQSO::setDefaultData()
 {
    //qDebug() << Q_FUNC_INFO << " - Start";
     palRed.setColor(QPalette::Text, Qt::red);
-    palBlack.setColor(QPalette::Text, Qt::black);
-    palWhite.setColor(QPalette::Text, Qt::white);
     completedWithPreviousName = false;
     completedWithPreviousQTH = false;
     completedWithPreviousLocator = false;
@@ -294,15 +292,6 @@ void MainWindowInputQSO::setDefaultData()
     freqTX = Frequency(0.0);
     freqRX = Frequency(0.0);
     modify = false;
-    readDarkMode();
-}
-
-void MainWindowInputQSO::readDarkMode()
-{
-    QSettings settings(util->getCfgFile (), QSettings::IniFormat);
-    settings.beginGroup ("Colors");
-    setDarkMode(settings.value("DarkMode", false).toBool ());
-    settings.endGroup ();
 }
 
 void MainWindowInputQSO::clear()
@@ -620,75 +609,27 @@ void MainWindowInputQSO::setPaletteRightName(const bool _ok)
 {
    //qDebug() << Q_FUNC_INFO << " - Start";
     if (_ok)
-    {
-        if (darkMode)
-        {
-            nameLineEdit->setPalette (palWhite);
-        }
-        else
-        {
-            nameLineEdit->setPalette (palBlack);
-        }
-    }
+        nameLineEdit->unsetPalette();
     else
-    {
         nameLineEdit->setPalette (palRed);
-    }
 }
 
 void MainWindowInputQSO::setPaletteRightQTH(const bool _ok)
 {
    //qDebug() << Q_FUNC_INFO << " - Start";
     if (_ok)
-    {
-        if (darkMode)
-        {
-            qthLineEdit->setPalette (palWhite);
-        }
-        else
-        {
-            qthLineEdit->setPalette (palBlack);
-        }
-    }
+        qthLineEdit->unsetPalette();
     else
-    {
         qthLineEdit->setPalette (palRed);
-    }
 }
 
 void MainWindowInputQSO::setPaletteRightDXLocator(const bool _ok)
 {
    //qDebug() << Q_FUNC_INFO << " - Start";
     if (_ok)
-    {
-        if (darkMode)
-        {
-            locatorLineEdit->setPalette (palWhite);
-        }
-        else
-        {
-            locatorLineEdit->setPalette (palBlack);
-        }
-    }
+        locatorLineEdit->unsetPalette();
     else
-    {
         locatorLineEdit->setPalette (palRed);
-    }
-}
-
-void MainWindowInputQSO::setDarkMode (const bool _dm)
-{
-    darkMode = _dm;
-
-    if (darkMode) {
-        txFreqSpinBox->setPalette(palWhite);
-        rxFreqSpinBox->setPalette(palWhite);
-        //qDebug() << Q_FUNC_INFO << " - DarkMode: ON";
-    } else {
-        //qDebug() << Q_FUNC_INFO << " - DarkMode: OFF";
-        txFreqSpinBox->setPalette(palBlack);
-        rxFreqSpinBox->setPalette(palBlack);
-    }
 }
 
 void MainWindowInputQSO::setPropModeFromSat(const QString &_p)
@@ -718,13 +659,7 @@ void MainWindowInputQSO::slotFreqTXChanged(const double _f)
    int bandId = dataProxy->getBandIdFromFreq(f1);
    if (bandId > 1) { // If the freq belongs to one ham band
        txFreqSpinBox->setToolTip(tr("TX Frequency in MHz."));
-       if (darkMode) {
-           //qDebug() << Q_FUNC_INFO << " - We are in darkmode";
-           txFreqSpinBox->setPalette(palWhite);
-       } else {
-           //qDebug() << Q_FUNC_INFO << " - We are NOT in darkmode";
-           txFreqSpinBox->setPalette(palBlack);
-       }
+       txFreqSpinBox->unsetPalette();
        //qDebug() << Q_FUNC_INFO << ": emitting: " << QString::number(_f);
         emit txFreqChanged (f1);
    } else {
@@ -764,13 +699,7 @@ void MainWindowInputQSO::slotFreqRXChanged(const double _f)
    freqRX = f1;
    int bandId = dataProxy->getBandIdFromFreq(f1);
    if (bandId > 1) { // If the freq belongs to one ham band
-       if (darkMode) {
-           //qDebug() << Q_FUNC_INFO << " - We are in darkmode";
-           rxFreqSpinBox->setPalette(palWhite);
-       } else {
-           //qDebug() << Q_FUNC_INFO << " - We are NOT in darkmode";
-           rxFreqSpinBox->setPalette(palBlack);
-       }
+       rxFreqSpinBox->unsetPalette();
        rxFreqSpinBox->setToolTip(tr("RX Frequency in MHz."));
        emit rxFreqChanged(Frequency(rxFreqSpinBox->value()));
     }

--- a/src/inputwidgets/mainwindowinputqso.h
+++ b/src/inputwidgets/mainwindowinputqso.h
@@ -45,7 +45,6 @@ class MainWindowInputQSO : public QWidget
 public:
     explicit MainWindowInputQSO(DataProxy_SQLite *dp, QWidget *parent = nullptr);
     ~MainWindowInputQSO();
-    void setDarkMode (const bool _dm);
     void setPaletteRightName(const bool _ok);
     void setPaletteRightQTH(const bool _ok);
     void setPaletteRightDXLocator(const bool _ok);
@@ -114,9 +113,6 @@ private:
     bool eventFilter(QObject *object, QEvent *event);
     void createUI();
     void setDefaultData();
-    bool getDarkMode();
-    //oid setSplitCheckBox();
-    void readDarkMode();
 
 
     QLineEdit *rstTXLineEdit, *rstRXLineEdit, *qthLineEdit, *locatorLineEdit, *nameLineEdit;
@@ -128,13 +124,12 @@ private:
     DataProxy_SQLite *dataProxy;
     Utilities *util;
 
-    QPalette palRed, palBlack, palWhite; // To paint Text in red or black(normal)
+    QPalette palRed; // To paint Text in red (validation error)
 
     bool rxFreqBeingAutoChanged, txFreqBeingAutoChanged, isSATPropagation;
     QString propMode;
     Frequency freqTX, freqRX;
     bool modify, completedWithPreviousName, completedWithPreviousQTH, completedWithPreviousLocator;
-    bool darkMode;
      bool fillingQSO;        // TRUE just when a QSO is being written in the UI from a qsoToEdit
 };
 

--- a/src/inputwidgets/mainwindowmydatatab.cpp
+++ b/src/inputwidgets/mainwindowmydatatab.cpp
@@ -53,7 +53,6 @@ MainWindowMyDataTab::MainWindowMyDataTab(DataProxy_SQLite *dp, QWidget *parent) 
     myLocator   = QString();          // Defined in the configuration by the user, will be used if the user configured so in the setup
     util        = new Utilities(Q_FUNC_INFO);
     modify      = false;
-    darkMode    = false;
     createUI();
     setInitialADIFValues();
     myPower = 0;
@@ -71,13 +70,6 @@ MainWindowMyDataTab::~MainWindowMyDataTab()
     //delete(dataProxy);
 }
 
-void MainWindowMyDataTab::readDarkMode()
-{
-    QSettings settings(util->getCfgFile (), QSettings::IniFormat);
-    settings.beginGroup ("Colors");
-    setDarkMode(settings.value("DarkMode", false).toBool ());
-    settings.endGroup ();
-}
 
 QSO MainWindowMyDataTab::getQSOData(QSO _qso)
 {
@@ -121,8 +113,6 @@ void MainWindowMyDataTab::createUI()
     //qDebug() << Q_FUNC_INFO;
     logEvent (Q_FUNC_INFO, "Start", Debug);
     palRed.setColor(QPalette::Text, Qt::red);
-    palBlack.setColor(QPalette::Text, Qt::black);
-    palWhite.setColor(QPalette::Text, Qt::white);
 
     myPowerSpinBox->setDecimals(2);
     myPowerSpinBox->setMaximum(9999);
@@ -171,7 +161,6 @@ void MainWindowMyDataTab::createUI()
     connect(myUserADIFComboBox, SIGNAL(currentTextChanged(QString)), this, SLOT(slotMyUserADIFComboBoxChanged() ) ) ;
 
     connect(myUserADIFLineEdit, SIGNAL(textChanged(QString)), this, SLOT(slotSetCurrentMyUSerData() ) );
-    readDarkMode();
     logEvent (Q_FUNC_INFO, "END", Debug);
 }
 
@@ -270,15 +259,7 @@ void MainWindowMyDataTab::slotMyLocatorTextChanged()
             myLocator = (myLocatorLineEdit->text()).toUpper();
         }
 
-        if (darkMode)
-        {
-            myLocatorLineEdit->setPalette(palWhite);
-        }
-        else
-        {
-            myLocatorLineEdit->setPalette(palBlack);
-        }
-
+        myLocatorLineEdit->unsetPalette();
         myLocatorLineEdit->setToolTip(tr("My QTH locator."));
         myLocatorLineEdit->setCursorPosition(cursorP);
         emit myLocChangedSignal(myLocatorLineEdit->text());
@@ -450,14 +431,7 @@ void MainWindowMyDataTab::slotOperatorTextChanged()
     Callsign callsign(operatorLineEdit->text());
     if (callsign.isValid())
     {
-        if (darkMode)
-        {
-            operatorLineEdit->setPalette(palWhite);
-        }
-        else
-        {
-            operatorLineEdit->setPalette(palBlack);
-        }
+        operatorLineEdit->unsetPalette();
 
         if (!modify)
         {
@@ -478,25 +452,6 @@ void MainWindowMyDataTab::slotOperatorTextChanged()
     operatorLineEdit->setCursorPosition(cursorP);
 }
 
-void MainWindowMyDataTab::setDarkMode (const bool _dm)
-{
-    darkMode = _dm;
-    if (darkMode)
-    {
-        myLocatorLineEdit->setPalette(palWhite);
-        operatorLineEdit->setPalette(palWhite);
-        stationCallSignLineEdit->setPalette(palWhite);
-        myUserADIFLineEdit->setPalette(palWhite);
-    }
-    else
-    {
-        myLocatorLineEdit->setPalette(palBlack);
-        operatorLineEdit->setPalette(palBlack);
-        stationCallSignLineEdit->setPalette(palBlack);
-        myUserADIFLineEdit->setPalette(palBlack);
-    }
-}
-
 void MainWindowMyDataTab::slotStationCallSignTextChanged()
 {
     //qDebug() << Q_FUNC_INFO;
@@ -507,20 +462,9 @@ void MainWindowMyDataTab::slotStationCallSignTextChanged()
 
     Callsign callsign(stationCallSignLineEdit->text());
     if (callsign.isValid())
-    {
-     if (darkMode)
-        {
-            stationCallSignLineEdit->setPalette(palWhite);
-        }
-        else
-        {
-            stationCallSignLineEdit->setPalette(palBlack);
-        }
-    }
+        stationCallSignLineEdit->unsetPalette();
     else
-    {
         stationCallSignLineEdit->setPalette(palRed);
-    }
     stationCallSignLineEdit->setCursorPosition(cursorP);
 }
 
@@ -794,14 +738,7 @@ QString MainWindowMyDataTab::getMyWWFF_Ref()
 void MainWindowMyDataTab::setColorsForMyUserADIFLineEdit()
 {
     logEvent (Q_FUNC_INFO, "Start", Debug);
-    if (darkMode)
-    {
-        myUserADIFLineEdit->setPalette(palWhite);
-    }
-    else
-    {
-        myUserADIFLineEdit->setPalette(palBlack);
-    }
+    myUserADIFLineEdit->unsetPalette();
 }
 
 void MainWindowMyDataTab::slotMyUserADIFComboBoxChanged()

--- a/src/inputwidgets/mainwindowmydatatab.h
+++ b/src/inputwidgets/mainwindowmydatatab.h
@@ -50,7 +50,6 @@ public:
 
     QSO getQSOData(QSO _qso);
     void setQSOData(const QSO &_qso);
-    void setDarkMode (const bool _dm);
     void createUI();
 
     void setData(const QString &_stationCallsign, const QString &_operator, const QString &_myLocator);
@@ -123,8 +122,6 @@ private:
     bool setInitialADIFValues();
     void setColorsForMyUserADIFLineEdit();
     bool checkMyVUCC_GRIDS(const QString &_string);
-    void readDarkMode();
-    bool darkMode;
     QStringList adifValidTypes;
 
     QDoubleSpinBox *myPowerSpinBox;
@@ -136,7 +133,7 @@ private:
     QComboBox *myUserADIFComboBox;
     QCheckBox *keepThisDataForNextQSOQCheckbox;
 
-    QPalette palRed, palBlack, palWhite; // To paint Text in red or black(normal)
+    QPalette palRed; // To paint Text in red (validation error)
     Locator *locator;
     DataProxy_SQLite *dataProxy;
     Utilities *util;

--- a/src/inputwidgets/mainwindowsattab.cpp
+++ b/src/inputwidgets/mainwindowsattab.cpp
@@ -56,8 +56,6 @@ MainWindowSatTab::MainWindowSatTab(DataProxy_SQLite *dp, QWidget *parent) :
     satNameLineEdit->setEnabled(false);
     satOtherLabel->setEnabled(false);
     palRed.setColor(QPalette::Text, Qt::red);
-    palBlack.setColor(QPalette::Text, Qt::black);
-    palWhite.setColor(QPalette::Text, Qt::white);
 
     setDefaultBands(); //TODO: Check how the bands are included not to create an inconsistence with the selected (in the setup) bands
        //qDebug() << "MainWindowSatTab::MainWindowSatTab - END"  ;
@@ -931,16 +929,4 @@ bool MainWindowSatTab::getKeep()
 //    return keepThisDataForNextQSOQcheckbox->isChecked();
 //}
 
-bool MainWindowSatTab::getDarkMode()
-{
-    //qDebug() << Q_FUNC_INFO << " - Start";
-    if (satNameLineEdit->palette().color (QPalette::Base) == "#646464")
-    {
-        return true;
-    }
-    else
-    {
-        return false;
-    }
-}
 

--- a/src/inputwidgets/mainwindowsattab.h
+++ b/src/inputwidgets/mainwindowsattab.h
@@ -131,7 +131,7 @@ private:
 
     bool updatingBands, updatingSat;
     bool qsoToEditInProcess;             // True just when MainWindow::qsoToEdit is being executed
-    QPalette palRed, palBlack, palWhite; // To paint Text in red or black(normal)
+    QPalette palRed; // To paint Text in red (validation error)
 
     // qDoubleSpinBox *txFreqSpinBox, *rxFreqSpinBox;
     DataProxy_SQLite *dataProxy;
@@ -143,7 +143,6 @@ private:
     QString downLinkBand, upLinkBand;
 
     bool modifying;
-    bool getDarkMode();
 };
 
 #endif // MAINWINDOWSATTAB_H

--- a/src/mainqsoentrywidget.cpp
+++ b/src/mainqsoentrywidget.cpp
@@ -134,8 +134,6 @@ void MainQSOEntryWidget::createUI()
     setLayout(widgetLayout);
 
     palRed.setColor(QPalette::Text, Qt::red);
-    palBlack.setColor(QPalette::Text, Qt::black);
-    palWhite.setColor(QPalette::Text, Qt::white);
 
     connect(util, SIGNAL(debugLog(QString, QString, DebugLogLevel)), this, SLOT(slotCaptureDebugLogs(QString, QString, DebugLogLevel)));
     connect(qrzLineEdit, SIGNAL(returnPressed()), this, SLOT(slotOKButtonClicked() ) );
@@ -297,14 +295,7 @@ void MainQSOEntryWidget::slotQRZTextChanged()
     else
     {
           //qDebug()<< "MainQSOEntryWidget::slotQRZTextChanged: QRZ is valid - Black";
-        if (getDarkMode())
-        {
-            qrzLineEdit->setPalette(palWhite);
-        }
-        else
-        {
-            qrzLineEdit->setPalette(palBlack);
-        }
+        qrzLineEdit->unsetPalette();
 
         currentQrz = qrzLineEdit->text();
         //emit showInfoLabel(tr(""));
@@ -1169,13 +1160,6 @@ void MainQSOEntryWidget::slotDelayInputTimedOut()
         slotQRZTextChanged();
     }
     logEvent (Q_FUNC_INFO, "END", Debug);
-}
-
-bool MainQSOEntryWidget::getDarkMode()
-{
-    logEvent (Q_FUNC_INFO, "Start-End", Debug);
-   //qDebug()<< Q_FUNC_INFO;
-    return (OKButton->palette().color (QPalette::Base) == "#646464");
 }
 
 bool MainQSOEntryWidget::eventFilter(QObject *object, QEvent *event)

--- a/src/mainqsoentrywidget.h
+++ b/src/mainqsoentrywidget.h
@@ -89,7 +89,6 @@ public:
     void setFocusToOK();
     void setLogLevel (const DebugLogLevel _b);
     void clear();
-    bool getDarkMode();
 
 protected:
     //void keyPressEvent(QKeyEvent *event);
@@ -163,7 +162,7 @@ private:
     QTimer *timer;
     bool UTCTime, modify, realTime;
     bool displayLocal; // To detect if the user wants to see UTC or local
-    QPalette palRed, palBlack, palWhite; // To paint Text in red or black(normal)
+    QPalette palRed; // To paint Text in red (validation error)
     Utilities *util;
     QPalette::ColorRole enabledCR, disabledCR;
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -349,7 +349,6 @@ void MainWindow::init_variables()
     loggWinAct->setShortcut(Qt::CTRL | Qt::Key_L);
 
     palRed.setColor(QPalette::Text, Qt::red);
-    palBlack.setColor(QPalette::Text, Qt::black);
 
     clublogAnswer = -1;
    //qDebug() << Q_FUNC_INFO << " - Changing colors to default";
@@ -695,7 +694,6 @@ void MainWindow::createActionsCommon(){
     connect(setupDialog, SIGNAL(exitSignal(int)), this, SLOT(slotExitFromSlotDialog(int)) );
     //connect(setupDialog, SIGNAL(qrzcomAuto(bool)), this, SLOT(slotElogQRZCOMAutoCheckFromSetup(bool)) );
     connect(setupDialog, SIGNAL(finished(int)), this, SLOT(slotSetupDialogFinished(int)) );
-    connect(setupDialog, SIGNAL(darkModeChanged(bool)), this, SLOT(slotDarkModeChanged(bool)) );
 
     connect(tipsDialog, SIGNAL(findQSL2QSOSignal()), this, SLOT(slotSearchToolNeededQSLToSend()) );
     connect(tipsDialog, SIGNAL(fillInDXCCSignal()), this, SLOT(slotFillEmptyDXCCInTheLog()) );
@@ -6344,7 +6342,6 @@ bool MainWindow::loadSettings()
     workedColor = settings.value("WorkedColor").value<QColor>();
     confirmedColor = settings.value("ConfirmedColor").value<QColor>();
     defaultColor = settings.value("DefaultColor").value<QColor>();
-    bool darkMode = settings.value("DarkMode", false).toBool ();
 
    //qDebug() << Q_FUNC_INFO << " - NewOneColor:    " << newOneColor.name(QColor::HexRgb);
    //qDebug() << Q_FUNC_INFO << " - NewOneColor:    " << newOneColor.name();
@@ -6355,9 +6352,6 @@ bool MainWindow::loadSettings()
 
     settings.endGroup ();
     setColors(newOneColor, neededColor, workedColor, confirmedColor, defaultColor);
-
-    setupDialog->loadDarkMode ();
-    setDarkMode(darkMode);
 
       //qDebug() << Q_FUNC_INFO << " - 70 - misc";
     settings.beginGroup ("Misc");
@@ -6454,18 +6448,6 @@ bool MainWindow::loadSettings()
     logEvent(Q_FUNC_INFO, "END", Debug);
       //qDebug() << Q_FUNC_INFO << " - END";
     return true;
-}
-
-void MainWindow::setDarkMode(const bool _dm)
-{
-  othersTabWidget->setDarkMode(_dm);
-  QSOTabWidget->setDarkMode(_dm);
-  myDataTabWidget->setDarkMode(_dm);
-}
-
-void MainWindow::slotDarkModeChanged(const bool _dm)
-{
-   setDarkMode(_dm);
 }
 
 void MainWindow::selectTheLog(const int _i)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -331,11 +331,9 @@ private slots:
     void slotTakeOverFocusToMainQSOInput();
     void slotNewLogLevel(DebugLogLevel l);
     void slotQSO_SetMode(const QString _submode);
-    void slotDarkModeChanged(const bool _dm);
 
 private:
     //void setWidgetsOrder();
-    void setDarkMode(const bool _dm);
     void init_variables();      // Refactored from init()
     void checkDebugFile();      // Refactored from init()
     void checkExistingData();   // Refactored from init()
@@ -660,7 +658,7 @@ private:
     QString lotwSentDefault, qrzcomSentDefault, clublogSentDefault, eqslSentDefault;
     QString stx, srx;
 
-    QPalette palRed, palBlack; // To paint Text in red or black(normal)
+    QPalette palRed; // To paint Text in red (validation error)
     bool  alwaysADIF, needToSave, useDefaultLogFileName, upAndRunning, qrzSmallModDontCalculate, imperialSystem, sendQSLWhenRec, manageDxMarathon, completeWithPrevious, completedWithPreviousQTH, completedWithPreviousLocator, completedWithPreviousName, completedWithPreviousIOTA, completedWithPreviousQSLVia;
     // bool realTime, UTCTime;
     bool cleaning;

--- a/src/setupdialog.cpp
+++ b/src/setupdialog.cpp
@@ -179,8 +179,6 @@ void SetupDialog::connectActions()
     connect (userDataPage, SIGNAL(operatorsSignal(QString)), this, SLOT(slotSetOperators(QString)));
     connect (userDataPage, SIGNAL(enterKey()), this, SLOT(slotOkButtonClicked()));
     connect (eLogPage, SIGNAL(enterKey()), this, SLOT(slotOkButtonClicked()));
-    connect (colorsPage, SIGNAL(darkModeChanged(bool)), this, SLOT(slotDarkModeChanged(bool)));
-
     logEvent(Q_FUNC_INFO, "END", Debug);
 }
 
@@ -188,10 +186,6 @@ void SetupDialog::connectActions()
 //{
     //emit qrzcomAuto(_b);
 //}
-void SetupDialog::slotDarkModeChanged(const bool _dm)
-{
-    emit darkModeChanged(_dm);
-}
 
 void SetupDialog::setData(const QString &_softwareVersion, const QString &_callingFunction, const int _page, const bool _alreadyConfigured)
 {
@@ -339,12 +333,6 @@ void SetupDialog::changePage(QListWidgetItem *current, QListWidgetItem *previous
     pagesWidget->setCurrentIndex(contentsWidget->row(current));
     logEvent(Q_FUNC_INFO, "END", Debug);
 }
-void SetupDialog::loadDarkMode()
-{// Reads the config to setup the DarkMode
-    //qDebug() << Q_FUNC_INFO;
-    colorsPage->loadDarkMode ();
-}
-
 bool SetupDialog::loadSettings(const QString &_callingFunction)
 {
     //qDebug() << Q_FUNC_INFO << " - Start - " << _callingFunction;

--- a/src/setupdialog.h
+++ b/src/setupdialog.h
@@ -66,7 +66,6 @@ public:
     //void setQRZCOMAutoCheckActive(const bool _b);
     void checkIfNewBandOrMode();
     void setLogLevel(const DebugLogLevel _sev);
-    void loadDarkMode(); // Reads the config to setup the DarkMode
     bool hamlibSettingsChanged() const;
     int  getSelectedLog() const;
     bool logsWereModified() const;
@@ -77,7 +76,6 @@ signals:
     void exitSignal(const int status); // 1 = OK, -1 = NOK, 2 = Cancel clicked
     void queryError(QString functionFailed, QString errorCodeS, QString nativeError, QString failedQuery); // To alert about any failed query execution
     void debugLog (QString _func, QString _msg, DebugLogLevel _level);
-    void darkModeChanged(bool darkMode); // Signal to notify other widgets
     //void qrzcomAuto(bool);
     //void newLogRequested(const bool _s); // true show new log
 
@@ -91,7 +89,6 @@ private slots:
     void slotSetOperators(const QString &_p);            // We receive te station operators from the userData tab to fill the new log
     void slotQueryErrorManagement(QString functionFailed, QString errorCodeS, QString nativeError, QString failedQuery);
     void slotFocusOK();
-    void slotDarkModeChanged(const bool _dm);
     //void slotQRZCOMAuto(const bool _b);
 
 private:

--- a/src/setuppages/setuppagecolors.cpp
+++ b/src/setuppages/setuppagecolors.cpp
@@ -40,7 +40,6 @@ SetupPageColors::SetupPageColors(QWidget *parent) : QWidget(parent)
     defaultColorButton = new QPushButton;
     wsjtxColorButton = new QPushButton;
     klogColorButton = new QPushButton;
-    darkModeButton = new QPushButton;
 
     newOneColorButton->setText(tr("New One"));
     neededColorButton->setText(tr("Needed in this band"));
@@ -49,7 +48,6 @@ SetupPageColors::SetupPageColors(QWidget *parent) : QWidget(parent)
     defaultColorButton->setText(tr("Default"));
     wsjtxColorButton->setText(tr("WSJT-X palette"));
     klogColorButton->setText(tr("Default palette"));
-    darkModeButton->setText(tr("Dark Mode"));
 
     newOneColorButton->setToolTip(tr("Color when the DXCC is an ATNO (All Time New One)."));
     neededColorButton->setToolTip(tr("This DXCC was worked before in another band but not in the selected band. It may be needed due to the CQ, ITU, Grid, ..."));
@@ -58,7 +56,6 @@ SetupPageColors::SetupPageColors(QWidget *parent) : QWidget(parent)
     defaultColorButton->setToolTip(tr("Default color."));
     wsjtxColorButton->setToolTip(tr("Sets a palette of colors similar to the one used in WSJT-X."));
     klogColorButton->setToolTip(tr("Sets the default palette."));
-    darkModeButton->setToolTip(tr("Sets the Dark Mode"));
 
     newOneColorButton->setAutoFillBackground ( true );
 
@@ -74,7 +71,6 @@ SetupPageColors::SetupPageColors(QWidget *parent) : QWidget(parent)
     schemasLayout->setSpacing(40);
     schemasLayout->addWidget(wsjtxColorButton);
     schemasLayout->addWidget(klogColorButton);
-    schemasLayout->addWidget(darkModeButton);
 
     QGridLayout *mainLayout = new QGridLayout;
     mainLayout->addLayout(buttonsLayout, 0, 0);
@@ -89,7 +85,6 @@ SetupPageColors::SetupPageColors(QWidget *parent) : QWidget(parent)
     connect(defaultColorButton, SIGNAL(clicked()), this, SLOT(slotDefaultColorButtonClicked()) );
     connect(wsjtxColorButton, SIGNAL(clicked()), this, SLOT(slotWSJTXButtonClicked()) );
     connect(klogColorButton, SIGNAL(clicked()), this, SLOT(slotKLogButtonClicked()) );
-    connect(darkModeButton, SIGNAL(clicked()), this, SLOT(slotSetDarkMode()) );
 
     setDefaultColors();
 
@@ -259,72 +254,6 @@ void SetupPageColors::slotKLogButtonClicked()
     setDefaultColors();
 }
 
-void SetupPageColors::loadDarkMode()
-{// Reads the config to setup the DarkMode
-    //qDebug() << Q_FUNC_INFO;
-    QSettings settings(util->getCfgFile (), QSettings::IniFormat);
-    settings.beginGroup ("Colors");
-    setDarkMode (settings.value("DarkMode", false).toBool ());
-    settings.endGroup ();
-}
-
-void SetupPageColors::slotSetDarkMode()
-{
-    setDarkMode (!darkMode);
-}
-
-QString SetupPageColors::getDarkMode()
-{
-    //qDebug() << Q_FUNC_INFO;
-    return util->boolToQString(darkMode);
-}
-
-void SetupPageColors::setDarkMode(const bool _d)
-{
-    //qDebug() << Q_FUNC_INFO << ": " << util->boolToQString (_d);
-    darkMode = _d;
-    if (darkMode)
-    {
-        // qApplication::setStyle(QStyleFactory::create("Fusion"));
-        QApplication::setStyle("fusion");
-
-        QPalette p;
-        p = qApp->palette();
-        p.setColor(QPalette::Window, QColor(53,53,53));
-        p.setColor(QPalette::Text, Qt::white);
-        p.setColor(QPalette::Button, QColor(53,53,53));
-        p.setColor(QPalette::Highlight, QColor(142,45,197));
-        p.setColor(QPalette::ButtonText, Qt::white);
-        p.setColor(QPalette::WindowText, Qt::white);
-        p.setColor(QPalette::Base, QColor(100,100,100));
-        p.setColor(QPalette::ToolTipBase, Qt::white);
-        p.setColor(QPalette::ToolTipText, Qt::black);
-        qApp->setPalette(p);
-        darkModeButton->setText(tr("Light Mode"));
-        //darkMode = true;
-    }
-    else
-    {
-        // qApplication::setStyle(QStyleFactory::create("Fusion"));
-        QApplication::setStyle("fusion");
-        QPalette p;
-        p = qApp->palette();
-        p.setColor(QPalette::Window, QColor(244,246,246));
-        p.setColor(QPalette::Text, Qt::black);
-        p.setColor(QPalette::Button, QColor(234,237,237));
-        p.setColor(QPalette::Highlight, QColor(40,120,240));
-        p.setColor(QPalette::ButtonText, Qt::black);
-        p.setColor(QPalette::WindowText, QColor(33,47,60));
-        p.setColor(QPalette::Base, Qt::white);
-        p.setColor(QPalette::ToolTipBase, Qt::white);
-        p.setColor(QPalette::ToolTipText, Qt::black);
-        qApp->setPalette(p);
-        darkModeButton->setText(tr("Dark Mode"));
-        //darkMode = false;
-    }
-    emit darkModeChanged(darkMode);
-}
-
 void SetupPageColors::saveSettings()
 {
     //qDebug() << Q_FUNC_INFO ;
@@ -336,7 +265,6 @@ void SetupPageColors::saveSettings()
     settings.setValue ("WorkedColor", (workedColorButton->palette().color(QPalette::Button)).name(QColor::HexRgb));
     settings.setValue ("ConfirmedColor", (confirmedColorButton->palette().color(QPalette::Button)).name(QColor::HexRgb));
     settings.setValue ("DefaultColor", (defaultColorButton->palette().color(QPalette::Button)).name(QColor::HexRgb));
-    settings.setValue ("DarkMode", QVariant(darkMode));
     settings.endGroup ();
 }
 
@@ -352,6 +280,5 @@ void SetupPageColors::loadSettings()
     setWorkedColor (settings.value("WorkedColor", "#FFD700").toString ());
     setConfirmedColor (settings.value("ConfirmedColor", "#32CD32").toString ());
     setDefaultColor (settings.value("DefaultColor", "#00BFFF").toString ());
-    setDarkMode (settings.value("DarkMode", false).toBool ());
     settings.endGroup ();
 }

--- a/src/setuppages/setuppagecolors.h
+++ b/src/setuppages/setuppagecolors.h
@@ -43,17 +43,14 @@ public:
     QString getWorkedColor();
     QString getConfirmedColor();
     QString getDefaultColor();
-    QString getDarkMode();
 
     void setNewOneColor(const QString &_c);
     void setNeededColor(const QString &_c);
     void setWorkedColor(const QString &_c);
     void setConfirmedColor(const QString &_c);
     void setDefaultColor(const QString &_c);
-    void setDarkMode(const bool _d);
     void saveSettings();
     void loadSettings();
-    void loadDarkMode(); // Reads the config to setup the DarkMode
 
 private slots:
     void slotNewOneColorButtonClicked();
@@ -63,13 +60,9 @@ private slots:
     void slotDefaultColorButtonClicked();
     void slotWSJTXButtonClicked();
     void slotKLogButtonClicked();
-    void slotSetDarkMode();
-signals:
-    void darkModeChanged(bool darkMode); // Signal to notify other widgets
 
 private:
     Utilities *util;
-    bool darkMode;
     void setDefaultColors();
     void setWSJTXColors();
     QColor giveColor (QColor c);
@@ -82,7 +75,6 @@ private:
     QPushButton *defaultColorButton;  // In this band
     QPushButton *wsjtxColorButton;  // In this band
     QPushButton *klogColorButton;  // In this band
-    QPushButton *darkModeButton;
 
     QColor color;
 /*

--- a/src/setuppages/setuppageelog.cpp
+++ b/src/setuppages/setuppageelog.cpp
@@ -35,7 +35,6 @@ SetupPageELog::SetupPageELog(QWidget *parent) : QWidget(parent)
     util = new Utilities(Q_FUNC_INFO);
 
     palRed.setColor(QPalette::Text, Qt::red);
-    palBlack.setColor(QPalette::Text, Qt::black);
 
     clubLogEmailLineEdit = new QLineEdit;
     clubLogPasswordLineEdit = new QLineEdit;
@@ -383,7 +382,7 @@ void SetupPageELog::slotQRZCallTextChanged()
     if (callsign.isValid())
     {
         //qDebug() << Q_FUNC_INFO << " -  -2.1";
-        QRZCOMUserLineEdit->setPalette(palBlack);
+        QRZCOMUserLineEdit->unsetPalette();
     }
     else
     {
@@ -409,7 +408,7 @@ void SetupPageELog::sloteQSLCallTextChanged()
     Callsign callsign(aux);
     if (callsign.isValid())
     {
-        eQSLUserLineEdit->setPalette(palBlack);
+        eQSLUserLineEdit->unsetPalette();
     }
     else
     {
@@ -438,7 +437,7 @@ void SetupPageELog::slotLoTWEmailDefineColor()
     Callsign callsign(aux);
     if (callsign.isValid())
     {
-        lotwUserLineEdit->setPalette(palBlack);
+        lotwUserLineEdit->unsetPalette();
     }
     else
     {
@@ -543,7 +542,7 @@ void SetupPageELog::slotPathLineEditChanged(const QString &_q)
 {
     if (QFile::exists(_q))
     {
-        lotwTQSLPathLineEdit->setPalette(palBlack);
+        lotwTQSLPathLineEdit->unsetPalette();
     }
     else
     {

--- a/src/setuppages/setuppageelog.h
+++ b/src/setuppages/setuppageelog.h
@@ -119,7 +119,7 @@ private:
 
     Utilities *util;
 
-    QPalette palRed, palBlack;
+    QPalette palRed;
 };
 
 #endif // SETUPPAGEELOG_H

--- a/src/src.pro
+++ b/src/src.pro
@@ -103,7 +103,7 @@ HEADERS += setupdialog.h \
     charts/statssentconfirmedpiechartwidget.h \
     database/database.h \
     database/datacache.h \
-    database/db_adif_primary_subdvisions_data.h \
+    database/db_adif_primary_subdivisions_data.h \
     database/queryexecutor.h \
     dataproxy_sqlite.h \
     downloadcty.h \
@@ -189,7 +189,7 @@ SOURCES += main.cpp \
     charts/statsfieldperbandwidget.cpp \
     database/database.cpp \
     database/datacache.cpp \
-    database/db_adif_primary_subdvisions_data.cpp \
+    database/db_adif_primary_subdivisions_data.cpp \
     database/queryexecutor.cpp \
     dataproxy_sqlite.cpp \
     dxcluster/dxspot.cpp \

--- a/tests/tst_database/CMakeLists.txt
+++ b/tests/tst_database/CMakeLists.txt
@@ -29,14 +29,14 @@ add_executable(tst_database
         ../../src/callsign.cpp
         ../../src/database/datacache.cpp
         ../../src/database/queryexecutor.cpp
-        ../../src/database/db_adif_primary_subdvisions_data.cpp
+        ../../src/database/db_adif_primary_subdivisions_data.cpp
         ../../src/database/database.cpp
 
     ${TEST_HEADERS}
     ../../src/database/database.h
     ../../src/database/datacache.h
     ../../src/database/queryexecutor.h
-    ../../src/database/db_adif_primary_subdvisions_data.h
+    ../../src/database/db_adif_primary_subdivisions_data.h
     ../../src/global.h
     ../../src/adif.h
     ../../src/frequency.h

--- a/tests/tst_database/tst_database.cpp
+++ b/tests/tst_database/tst_database.cpp
@@ -28,7 +28,7 @@
 #include <QtTest>
 #include "../../src/database/database.h"
 #include "../../src/database/datacache.h"
-#include "../../src/database/db_adif_primary_subdvisions_data.h"
+#include "../../src/database/db_adif_primary_subdivisions_data.h"
 #include "../../src/database/queryexecutor.h"
 #include "../../src/dataproxy_sqlite.h"
 #include "../../src/qso.h"

--- a/tests/tst_database/tst_database.pro
+++ b/tests/tst_database/tst_database.pro
@@ -13,7 +13,7 @@ HEADERS += \
     ../../src/database/database.h \
     ../../src/database/datacache.h \
     ../../src/database/queryexecutor.h \
-    ../../src/database/db_adif_primary_subdvisions_data.h \
+    ../../src/database/db_adif_primary_subdivisions_data.h \
     ../../src/global.h \
     ../../src/adif.h \
     ../../src/frequency.h \
@@ -37,7 +37,7 @@ SOURCES +=  tst_database.cpp \
         ##../../src/qsodatacache.cpp \
         ../../src/callsign.cpp \
         ../../src/database/queryexecutor.cpp \
-        ../../src/database/db_adif_primary_subdvisions_data.cpp \
+        ../../src/database/db_adif_primary_subdivisions_data.cpp \
         ../../src/database/database.cpp
 
 isEmpty(QMAKE_LRELEASE) {

--- a/tests/tst_datacache/,
+++ b/tests/tst_datacache/,
@@ -13,7 +13,7 @@ HEADERS += \
     ../../src/database/database.h \
     ../../src/database/datacache.h \
     ../../src/database/queryexecutor.h \
-    ../../src/database/db_adif_primary_subdvisions_data.h \
+    ../../src/database/db_adif_primary_subdivisions_data.h \
     ../../src/global.h \
     ../../src/adif.h \
     ../../src/frequency.h \
@@ -38,7 +38,7 @@ SOURCES +=  tst_database.cpp \
         ##../../src/qsodatacache.cpp \
         ../../src/callsign.cpp \
         ../../src/database/queryexecutor.cpp \
-        ../../src/database/db_adif_primary_subdvisions_data.cpp \
+        ../../src/database/db_adif_primary_subdivisions_data.cpp \
         ../../src/database/database.cpp
 
 isEmpty(QMAKE_LRELEASE) {

--- a/tests/tst_datacache/CMakeLists.txt
+++ b/tests/tst_datacache/CMakeLists.txt
@@ -27,7 +27,7 @@ add_executable(tst_datacache
         ../../src/callsign.cpp
         ../../src/database/datacache.cpp
         ../../src/database/queryexecutor.cpp
-        ../../src/database/db_adif_primary_subdvisions_data.cpp
+        ../../src/database/db_adif_primary_subdivisions_data.cpp
         ../../src/database/database.cpp
 
 
@@ -35,7 +35,7 @@ add_executable(tst_datacache
     ../../src/database/database.h
     ../../src/database/datacache.h
     ../../src/database/queryexecutor.h
-    ../../src/database/db_adif_primary_subdvisions_data.h
+    ../../src/database/db_adif_primary_subdivisions_data.h
     ../../src/global.h
     ../../src/adif.h
     ../../src/frequency.h

--- a/tests/tst_dataproxy/CMakeLists.txt
+++ b/tests/tst_dataproxy/CMakeLists.txt
@@ -23,7 +23,7 @@ add_executable(tst_dataproxy
         ../../src/database/database.cpp
         ../../src/database/datacache.cpp
         ../../src/database/queryexecutor.cpp
-        ../../src/database/db_adif_primary_subdvisions_data.cpp
+        ../../src/database/db_adif_primary_subdivisions_data.cpp
         ../../src/frequency.cpp
         ../../src/qso.cpp
         ../../src/qsodatacache.cpp
@@ -39,7 +39,7 @@ add_executable(tst_dataproxy
     ../../src/database/database.h
     ../../src/database/datacache.h
     ../../src/database/queryexecutor.h
-    ../../src/database/db_adif_primary_subdvisions_data.h
+    ../../src/database/db_adif_primary_subdivisions_data.h
     ../../src/frequency.h
     ../../src/qso.h
     ../../src/qsodatacache.h

--- a/tests/tst_dataproxy/tst_dataproxy.pro
+++ b/tests/tst_dataproxy/tst_dataproxy.pro
@@ -14,7 +14,7 @@ HEADERS += \
     ../../src/locator.h \
     ../../src/database/database.h \
     ../../src/database/queryexecutor.h \
-    ../../src/database/db_adif_primary_subdvisions_data.h \
+    ../../src/database/db_adif_primary_subdivisions_data.h \
     ../../src/frequency.h \
     ../../src/qso.h \
     ##../../src/qsodatacache.h \
@@ -28,7 +28,7 @@ SOURCES +=  tst_dataproxy.cpp \
         ../../src/locator.cpp \
         ../../src/database/database.cpp \
         ../../src/database/queryexecutor.cpp \
-        ../../src/database/db_adif_primary_subdvisions_data.cpp \
+        ../../src/database/db_adif_primary_subdivisions_data.cpp \
         ../../src/frequency.cpp \
         ../../src/qso.cpp \
         ##../../src/qsodatacache.cpp \

--- a/tests/tst_dxcluster/CMakeLists.txt
+++ b/tests/tst_dxcluster/CMakeLists.txt
@@ -21,7 +21,7 @@ add_executable(tst_dxcluster
     ../../src/awarddxmarathon.cpp
     ../../src/callsign.cpp
     ../../src/database/datacache.cpp
-    ../../src/database/db_adif_primary_subdvisions_data.cpp
+    ../../src/database/db_adif_primary_subdivisions_data.cpp
     ../../src/database/database.cpp
     ../../src/database/queryexecutor.cpp
     ../../src/dataproxy_sqlite.cpp
@@ -40,7 +40,7 @@ add_executable(tst_dxcluster
     ../../src/awarddxmarathon.h
     ../../src/callsign.h
     ../../src/database/datacache.h
-    ../../src/database/db_adif_primary_subdvisions_data.h
+    ../../src/database/db_adif_primary_subdivisions_data.h
     ../../src/database/database.h
     ../../src/database/queryexecutor.h
     ../../src/dataproxy_sqlite.h

--- a/tests/tst_dxcluster/tst_dxcluster.pro
+++ b/tests/tst_dxcluster/tst_dxcluster.pro
@@ -42,7 +42,7 @@ HEADERS += \
     ../../src/awarddxmarathon.h \
     ../../src/callsign.h \
     ../../src/database/datacache.h \
-    ../../src/database/db_adif_primary_subdvisions_data.h \
+    ../../src/database/db_adif_primary_subdivisions_data.h \
     ../../src/database/database.h \
     ../../src/database/queryexecutor.h \
     ../../src/dataproxy_sqlite.h \
@@ -63,7 +63,7 @@ SOURCES += tst_dxcluster.cpp \
     ../../src/awarddxmarathon.cpp \
     ../../src/callsign.cpp \
     ../../src/database/datacache.cpp \
-    ../../src/database/db_adif_primary_subdvisions_data.cpp \
+    ../../src/database/db_adif_primary_subdivisions_data.cpp \
     ../../src/database/database.cpp \
     ../../src/database/queryexecutor.cpp \
     ../../src/dataproxy_sqlite.cpp \

--- a/tests/tst_filemanager/CMakeLists.txt
+++ b/tests/tst_filemanager/CMakeLists.txt
@@ -19,7 +19,7 @@ file(GLOB TEST_HEADERS "*.h")
 add_executable(tst_filemanager
     ${TEST_SOURCES}
     ../../src/adif.cpp
-    ../../src/database/db_adif_primary_subdvisions_data.cpp
+    ../../src/database/db_adif_primary_subdivisions_data.cpp
     ../../src/awards.cpp
     ../../src/awarddxmarathon.cpp
     ../../src/database/database.cpp
@@ -37,7 +37,7 @@ add_executable(tst_filemanager
 
     ${TEST_HEADERS}
     ../../src/adif.h
-    ../../src/database/db_adif_primary_subdvisions_data.h
+    ../../src/database/db_adif_primary_subdivisions_data.h
     ../../src/awards.h
     ../../src/awarddxmarathon.h
     ../../src/database/database.h

--- a/tests/tst_filemanager/tst_filemanager.pro
+++ b/tests/tst_filemanager/tst_filemanager.pro
@@ -11,7 +11,7 @@ TEMPLATE = app
 HEADERS += \
     ../../src/adif.h \
     ../../src/database/datacache.h \
-    ../../src/database/db_adif_primary_subdvisions_data.h \
+    ../../src/database/db_adif_primary_subdivisions_data.h \
     ../../src/awards.h \
     ../../src/awarddxmarathon.h \
     ../../src/database/database.h \
@@ -29,7 +29,7 @@ HEADERS += \
 SOURCES +=  tst_filemanager.cpp \
     ../../src/adif.cpp \
     ../../src/database/datacache.cpp \
-    ../../src/database/db_adif_primary_subdvisions_data.cpp \
+    ../../src/database/db_adif_primary_subdivisions_data.cpp \
     ../../src/awards.cpp \
     ../../src/awarddxmarathon.cpp \
     ../../src/database/database.cpp \

--- a/tests/tst_logwindow/CMakeLists.txt
+++ b/tests/tst_logwindow/CMakeLists.txt
@@ -24,7 +24,7 @@ add_executable(tst_logwindow
     ../../src/callsign.cpp
     ../../src/database/datacache.cpp
     ../../src/database/queryexecutor.cpp
-    ../../src/database/db_adif_primary_subdvisions_data.cpp
+    ../../src/database/db_adif_primary_subdivisions_data.cpp
     ../../src/frequency.cpp
     ../../src/database/database.cpp
     ../../src/dataproxy_sqlite.cpp
@@ -43,7 +43,7 @@ add_executable(tst_logwindow
     ../../src/awarddxmarathon.h
     ../../src/callsign.h
     ../../src/database/queryexecutor.h
-    ../../src/database/db_adif_primary_subdvisions_data.h
+    ../../src/database/db_adif_primary_subdivisions_data.h
     ../../src/frequency.h
     ../../src/database/database.h
     ../../src/database/datacache.h

--- a/tests/tst_logwindow/tst_logwindow.cpp
+++ b/tests/tst_logwindow/tst_logwindow.cpp
@@ -28,7 +28,7 @@
 #include <QtTest>
 #include "../../src/awards.h"
 #include "../../src/callsign.h"
-//#include "../../src/database/db_adif_primary_subdvisions_data.h"
+//#include "../../src/database/db_adif_primary_subdivisions_data.h"
 #include "../../src/dataproxy_sqlite.h"
 #include "../../src/awarddxmarathon.h"
 #include "../../src/logwindow.h"

--- a/tests/tst_logwindow/tst_logwindow.pro
+++ b/tests/tst_logwindow/tst_logwindow.pro
@@ -21,7 +21,7 @@ HEADERS += \
     ../../src/callsign.h \
     ../../src/database/datacache.h \
     ../../src/database/queryexecutor.h \
-    ../../src/database/db_adif_primary_subdvisions_data.h \
+    ../../src/database/db_adif_primary_subdivisions_data.h \
     ../../src/frequency.h \
     ../../src/database/database.h \
     ../../src/dataproxy_sqlite.h \
@@ -41,7 +41,7 @@ SOURCES += tst_logwindow.cpp \
     ../../src/callsign.cpp \
     ../../src/database/datacache.cpp \
     ../../src/database/queryexecutor.cpp \
-    ../../src/database/db_adif_primary_subdvisions_data.cpp \
+    ../../src/database/db_adif_primary_subdivisions_data.cpp \
     ../../src/frequency.cpp \
     ../../src/database/database.cpp \
     ../../src/dataproxy_sqlite.cpp \

--- a/tests/tst_mainqsoentrywidget/CMakeLists.txt
+++ b/tests/tst_mainqsoentrywidget/CMakeLists.txt
@@ -29,7 +29,7 @@ add_executable(tst_mainqsoentrywidget
     ../../src/database/database.cpp
     ../../src/database/datacache.cpp
     ../../src/database/queryexecutor.cpp
-    ../../src/database/db_adif_primary_subdvisions_data.cpp
+    ../../src/database/db_adif_primary_subdivisions_data.cpp
     ../../src/adif.cpp
 
     ${TEST_HEADERS}
@@ -45,7 +45,7 @@ add_executable(tst_mainqsoentrywidget
     ../../src/database/database.h
     ../../src/database/datacache.h
     ../../src/database/queryexecutor.h
-    ../../src/database/db_adif_primary_subdvisions_data.h
+    ../../src/database/db_adif_primary_subdivisions_data.h
       ../../src/adif.h
 )
 

--- a/tests/tst_mainqsoentrywidget/tst_mainqsoentrywidget.pro
+++ b/tests/tst_mainqsoentrywidget/tst_mainqsoentrywidget.pro
@@ -22,7 +22,7 @@ HEADERS += \
     ../../src/klogdefinitions.h \
     ../../src/database/database.h \
     ../../src/database/queryexecutor.h \
-    ../../src/database/db_adif_primary_subdvisions_data.h \
+    ../../src/database/db_adif_primary_subdivisions_data.h \
       ../../src/adif.h
 
 SOURCES +=  tst_mainqsoentrywidget.cpp \
@@ -37,7 +37,7 @@ SOURCES +=  tst_mainqsoentrywidget.cpp \
     ../../src/locator.cpp \
     ../../src/database/database.cpp \
     ../../src/database/queryexecutor.cpp \
-    ../../src/database/db_adif_primary_subdvisions_data.cpp \
+    ../../src/database/db_adif_primary_subdivisions_data.cpp \
     ../../src/adif.cpp
 
 

--- a/tests/tst_mainwindow/CMakeLists.txt
+++ b/tests/tst_mainwindow/CMakeLists.txt
@@ -89,7 +89,7 @@ add_executable(tst_mainwindow
   ../../src/database/database.cpp
   ../../src/database/datacache.cpp
   ../../src/database/queryexecutor.cpp
-  ../../src/database/db_adif_primary_subdvisions_data.cpp
+  ../../src/database/db_adif_primary_subdivisions_data.cpp
   ../../src/setuppages/hamlibnetworkconfigwidget.cpp
   ../../src/setuppages/hamlibserialconfigwidget.cpp
   ../../src/setuppages/setupentitydialog.cpp
@@ -204,7 +204,7 @@ add_executable(tst_mainwindow
   ../../src/database/database.h
   ../../src/database/datacache.h
   ../../src/database/queryexecutor.h
-  ../../src/database/db_adif_primary_subdvisions_data.h
+  ../../src/database/db_adif_primary_subdivisions_data.h
   ../../src/klogdefinitions.h
   ../../src/utilities.h
   ../../src/qso.h

--- a/tests/tst_mainwindow/tst_mainwindow.pro
+++ b/tests/tst_mainwindow/tst_mainwindow.pro
@@ -88,7 +88,7 @@ HEADERS += \
     ../../src/dataproxy_sqlite.h \
     ../../src/database.h \
     ../../src/database/queryexecutor.h \
-    ../../src/database/db_adif_primary_subdvisions_data.h \
+    ../../src/database/db_adif_primary_subdivisions_data.h \
     ../../src/klogdefinitions.h \
     ../../src/utilities.h \
     ../../src/qso.h \
@@ -167,7 +167,7 @@ SOURCES +=  tst_mainwindow.cpp \
     ../../src/dataproxy_sqlite.cpp \
     ../../src/database.cpp \
     ../../src/database/queryexecutor.cpp \
-    ../../src/database/db_adif_primary_subdvisions_data.cpp \
+    ../../src/database/db_adif_primary_subdivisions_data.cpp \
     ../../src/setuppages/hamlibnetworkconfigwidget.cpp \
     ../../src/setuppages/hamlibserialconfigwidget.cpp \
     ../../src/setuppages/setupentitydialog.cpp \

--- a/tests/tst_mainwindow/tst_mainwindow.pro
+++ b/tests/tst_mainwindow/tst_mainwindow.pro
@@ -56,7 +56,7 @@ HEADERS += \
     ../../src/inputwidgets/mainwindowinputeqsl.h \
     ../../src/inputwidgets/mainwindowinputqsl.h \
     ../../src/inputwidgets/mainwindowinputqso.h \
-    ../../src/elogclublog.h \
+    ../../src/elog/elogclublog.h \
     ../../src/downloadcty.h \
     ../../src/dxccstatuswidget.h \
     ../../src/awardswidget.h \
@@ -73,9 +73,10 @@ HEADERS += \
     ../../src/statisticswidget.h \
     ../../src/updatesatsdata.h \
     ../../src/hamlibclass.h \
-    ../../src/elogqrzlog.h \
-    ../../src/lotwutilities.h \
-    ../../src/eqslutilities.h \
+    ../../src/elog/elogqrzlog.h \
+    ../../src/elog/lotwutilities.h \
+    ../../src/elog/eqslutilities.h \
+    ../../src/database/datacache.h \
     ../../src/widgets/adiflotwexportwidget.h \
     ../../src/widgets/showadifimportwidget.h \
     ../../src/widgets/onlinemessagewidget.h \
@@ -135,7 +136,7 @@ SOURCES +=  tst_mainwindow.cpp \
     ../../src/inputwidgets/mainwindowinputqsl.cpp \
     ../../src/inputwidgets/mainwindowinputqso.cpp \
     ../../src/mainqsoentrywidget.cpp \
-    ../../src/elogclublog.cpp \
+    ../../src/elog/elogclublog.cpp \
     ../../src/downloadcty.cpp \
     ../../src/dxccstatuswidget.cpp \
     ../../src/awardswidget.cpp \
@@ -152,9 +153,10 @@ SOURCES +=  tst_mainwindow.cpp \
     ../../src/statisticswidget.cpp \
     ../../src/updatesatsdata.cpp \
     ../../src/hamlibclass.cpp \
-    ../../src/elogqrzlog.cpp \
-    ../../src/lotwutilities.cpp \
-    ../../src/eqslutilities.cpp \
+    ../../src/elog/elogqrzlog.cpp \
+    ../../src/elog/lotwutilities.cpp \
+    ../../src/elog/eqslutilities.cpp \
+    ../../src/database/datacache.cpp \
     ../../src/widgets/adiflotwexportwidget.cpp \
     ../../src/widgets/showadifimportwidget.cpp \
     ../../src/widgets/onlinemessagewidget.cpp \
@@ -219,6 +221,8 @@ macx: {
     CONFIG += c++11
     INCLUDEPATH +=/usr/local/include/
     LIBS += -L"/usr/local/lib" -lhamlib
+    INCLUDEPATH +=/opt/homebrew/Cellar/hamlib/4.6.5/include/
+    LIBS += -L"/opt/homebrew/Cellar/hamlib/4.6.5/lib" -lhamlib
 }
 
 #win32: {

--- a/tests/tst_mainwindowinputothers/CMakeLists.txt
+++ b/tests/tst_mainwindowinputothers/CMakeLists.txt
@@ -24,7 +24,7 @@ add_executable(tst_mainwindowinputothers
     ../../src/database/database.cpp
     ../../src/database/datacache.cpp
     ../../src/database/queryexecutor.cpp
-    ../../src/database/db_adif_primary_subdvisions_data.cpp
+    ../../src/database/db_adif_primary_subdivisions_data.cpp
     ../../src/frequency.cpp
     ../../src/qso.cpp
     ../../src/qsodatacache.cpp
@@ -40,7 +40,7 @@ add_executable(tst_mainwindowinputothers
     ../../src/database/database.h
     ../../src/database/datacache.h
     ../../src/database/queryexecutor.h
-    ../../src/database/db_adif_primary_subdvisions_data.h
+    ../../src/database/db_adif_primary_subdivisions_data.h
     ../../src/frequency.h
     ../../src/qso.h
     ../../src/qsodatacache.h

--- a/tests/tst_mainwindowinputothers/tst_mainwindowinputothers.pro
+++ b/tests/tst_mainwindowinputothers/tst_mainwindowinputothers.pro
@@ -16,7 +16,7 @@ HEADERS += \
     ../../src/database/database.h \
     ../../src/database/datacache.h \
     ../../src/database/queryexecutor.h \
-    ../../src/database/db_adif_primary_subdvisions_data.h \
+    ../../src/database/db_adif_primary_subdivisions_data.h \
     ../../src/frequency.h \
     ../../src/qso.h \
     #../../src/qsodatacache.h \
@@ -32,7 +32,7 @@ SOURCES +=  tst_mainwindowinputothers.cpp \
     ../../src/database/database.cpp \
     ../../src/database/datacache.cpp \
     ../../src/database/queryexecutor.cpp \
-    ../../src/database/db_adif_primary_subdvisions_data.cpp \
+    ../../src/database/db_adif_primary_subdivisions_data.cpp \
     ../../src/frequency.cpp \
     ../../src/qso.cpp \
     #../../src/qsodatacache.cpp \

--- a/tests/tst_mainwindowinputqso/CMakeLists.txt
+++ b/tests/tst_mainwindowinputqso/CMakeLists.txt
@@ -23,7 +23,7 @@ add_executable(tst_mainwindowinputqso
     ../../src/database/database.cpp
     ../../src/database/datacache.cpp
     ../../src/database/queryexecutor.cpp
-    ../../src/database/db_adif_primary_subdvisions_data.cpp
+    ../../src/database/db_adif_primary_subdivisions_data.cpp
     ../../src/frequency.cpp
     ../../src/qso.cpp
     ../../src/qsodatacache.cpp
@@ -38,7 +38,7 @@ add_executable(tst_mainwindowinputqso
     ../../src/database/database.h
     ../../src/database/datacache.h
     ../../src/database/queryexecutor.h
-    ../../src/database/db_adif_primary_subdvisions_data.h
+    ../../src/database/db_adif_primary_subdivisions_data.h
     ../../src/frequency.h
     ../../src/qso.h
     ../../src/qsodatacache.h

--- a/tests/tst_mainwindowinputqso/tst_mainwindowinputqso.pro
+++ b/tests/tst_mainwindowinputqso/tst_mainwindowinputqso.pro
@@ -15,7 +15,7 @@ HEADERS += \
     ../../src/database/database.h \
     ../../src/database/datacache.h \
     ../../src/database/queryexecutor.h \
-    ../../src/database/db_adif_primary_subdvisions_data.h \
+    ../../src/database/db_adif_primary_subdivisions_data.h \
     ../../src/frequency.h \
     ../../src/qso.h \
     #../../src/qsodatacache.h \
@@ -30,7 +30,7 @@ SOURCES +=  tst_mainwindowinputqso.cpp \
     ../../src/database/database.cpp \
     ../../src/database/datacache.cpp \
     ../../src/database/queryexecutor.cpp \
-    ../../src/database/db_adif_primary_subdvisions_data.cpp \
+    ../../src/database/db_adif_primary_subdivisions_data.cpp \
     ../../src/frequency.cpp \
     ../../src/qso.cpp \
     #../../src/qsodatacache.cpp \

--- a/tests/tst_mainwindowsattab/CMakeLists.txt
+++ b/tests/tst_mainwindowsattab/CMakeLists.txt
@@ -29,7 +29,7 @@ add_executable(tst_mainwindowsattab
     ../../src/database/database.cpp
     ../../src/database/datacache.cpp
     ../../src/database/queryexecutor.cpp
-    ../../src/database/db_adif_primary_subdvisions_data.cpp
+    ../../src/database/db_adif_primary_subdivisions_data.cpp
     ../../src/adif.cpp
 
 
@@ -46,7 +46,7 @@ add_executable(tst_mainwindowsattab
     ../../src/database/database.h
     ../../src/database/datacache.h
     ../../src/database/queryexecutor.h
-    ../../src/database/db_adif_primary_subdvisions_data.h
+    ../../src/database/db_adif_primary_subdivisions_data.h
     ../../src/adif.h
 )
 

--- a/tests/tst_mainwindowsattab/tst_mainwindowsattab.pro
+++ b/tests/tst_mainwindowsattab/tst_mainwindowsattab.pro
@@ -30,7 +30,7 @@ HEADERS += \
     ../../src/klogdefinitions.h \
     ../../src/database/database.h \
     ../../src/database/queryexecutor.h \
-    ../../src/database/db_adif_primary_subdvisions_data.h \
+    ../../src/database/db_adif_primary_subdivisions_data.h \
     ../../src/adif.h
 
 SOURCES +=  tst_mainwindowsattab.cpp \
@@ -45,7 +45,7 @@ SOURCES +=  tst_mainwindowsattab.cpp \
     ../../src/locator.cpp \
     ../../src/database/database.cpp \
     ../../src/database/queryexecutor.cpp \
-    ../../src/database/db_adif_primary_subdvisions_data.cpp \
+    ../../src/database/db_adif_primary_subdivisions_data.cpp \
     ../../src/adif.cpp
 
 

--- a/tests/tst_qso/CMakeLists.txt
+++ b/tests/tst_qso/CMakeLists.txt
@@ -20,7 +20,7 @@ add_executable(tst_qso
     ${TEST_SOURCES}
     ../../src/database/database.cpp
     ../../src/database/datacache.cpp
-    ../../src/database/db_adif_primary_subdvisions_data.cpp
+    ../../src/database/db_adif_primary_subdivisions_data.cpp
     ../../src/database/queryexecutor.cpp
     ../../src/utilities.cpp
     ../../src/callsign.cpp
@@ -33,7 +33,7 @@ add_executable(tst_qso
     ${TEST_HEADERS}
     ../../src/database/database.h
     ../../src/database/datacache.h
-    ../../src/database/db_adif_primary_subdvisions_data.h
+    ../../src/database/db_adif_primary_subdivisions_data.h
     ../../src/database/queryexecutor.h
     ../../src/utilities.h
     ../../src/callsign.h

--- a/tests/tst_qso/tst_qso.pro
+++ b/tests/tst_qso/tst_qso.pro
@@ -10,7 +10,7 @@ TEMPLATE = app
 
 HEADERS += \
     ../../src/database/database.h \
-    ../../src/database/db_adif_primary_subdvisions_data.h \
+    ../../src/database/db_adif_primary_subdivisions_data.h \
     ../../src/database/queryexecutor.h \
     ../../src/utilities.h \
     ../../src/callsign.h \
@@ -24,7 +24,7 @@ HEADERS += \
 
 SOURCES +=  tst_qso.cpp \
     ../../src/database/database.cpp \
-    ../../src/database/db_adif_primary_subdvisions_data.cpp \
+    ../../src/database/db_adif_primary_subdivisions_data.cpp \
     ../../src/database/queryexecutor.cpp \
     ../../src/utilities.cpp \
     ../../src/callsign.cpp \

--- a/tests/tst_setuppageelog/CMakeLists.txt
+++ b/tests/tst_setuppageelog/CMakeLists.txt
@@ -23,7 +23,7 @@ add_executable(tst_setuppageelog
     ../../src/database/database.cpp
     ../../src/database/datacache.cpp
     ../../src/database/queryexecutor.cpp
-    ../../src/database/db_adif_primary_subdvisions_data.cpp
+    ../../src/database/db_adif_primary_subdivisions_data.cpp
     ../../src/frequency.cpp
     ../../src/qso.cpp
     ../../src/qsodatacache.cpp
@@ -39,7 +39,7 @@ add_executable(tst_setuppageelog
     ../../src/database/database.h
     ../../src/database/datacache.h
     ../../src/database/queryexecutor.h
-    ../../src/database/db_adif_primary_subdvisions_data.h
+    ../../src/database/db_adif_primary_subdivisions_data.h
     ../../src/frequency.h
     ../../src/qso.h
     ../../src/qsodatacache.h

--- a/tests/tst_setuppageelog/tst_setuppageelog.pro
+++ b/tests/tst_setuppageelog/tst_setuppageelog.pro
@@ -16,7 +16,7 @@ HEADERS += \
     ../../src/dataproxy_sqlite.h \
     ../../src/database/database.h \
     ../../src/database/queryexecutor.h \
-    ../../src/database/db_adif_primary_subdvisions_data.h \
+    ../../src/database/db_adif_primary_subdivisions_data.h \
     ../../src/frequency.h \
     ../../src/qso.h \
     #../../src/qsodatacache.h \
@@ -32,7 +32,7 @@ SOURCES +=  tst_setuppageelog.cpp \
     ../../src/dataproxy_sqlite.cpp \
     ../../src/database/database.cpp \
     ../../src/database/queryexecutor.cpp \
-    ../../src/database/db_adif_primary_subdvisions_data.cpp \
+    ../../src/database/db_adif_primary_subdivisions_data.cpp \
     ../../src/frequency.cpp \
     ../../src/qso.cpp \
     #../../src/qsodatacache.cpp \

--- a/tests/tst_utilities/CMakeLists.txt
+++ b/tests/tst_utilities/CMakeLists.txt
@@ -23,7 +23,7 @@ add_executable(tst_utilities
     ../../src/database/database.cpp
     ../../src/database/datacache.cpp
     ../../src/database/queryexecutor.cpp
-    ../../src/database/db_adif_primary_subdvisions_data.cpp
+    ../../src/database/db_adif_primary_subdivisions_data.cpp
     ../../src/frequency.cpp
     ../../src/qso.cpp
     ../../src/qsodatacache.cpp
@@ -37,7 +37,7 @@ add_executable(tst_utilities
     ../../src/database/database.h
     ../../src/database/datacache.h
     ../../src/database/queryexecutor.h
-    ../../src/database/db_adif_primary_subdvisions_data.h
+    ../../src/database/db_adif_primary_subdivisions_data.h
     ../../src/frequency.h
     ../../src/qso.h
     ../../src/qsodatacache.h

--- a/tests/tst_utilities/tst_utilities.pro
+++ b/tests/tst_utilities/tst_utilities.pro
@@ -17,7 +17,7 @@ HEADERS += \
     ../../src/database/database.h \
     ../../src/database/datacache.h \
     ../../src/database/queryexecutor.h \
-    ../../src/database/db_adif_primary_subdvisions_data.h \
+    ../../src/database/db_adif_primary_subdivisions_data.h \
     ../../src/frequency.h \
     ../../src/qso.h \
     #../../src/qsodatacache.h \
@@ -32,7 +32,7 @@ SOURCES +=  tst_utilities.cpp \
     ../../src/database/database.cpp \
     ../../src/database/datacache.cpp \
     ../../src/database/queryexecutor.cpp \
-    ../../src/database/db_adif_primary_subdvisions_data.cpp \
+    ../../src/database/db_adif_primary_subdivisions_data.cpp \
     ../../src/frequency.cpp \
     ../../src/qso.cpp \
     #../../src/qsodatacache.cpp \

--- a/tests/tst_world/CMakeLists.txt
+++ b/tests/tst_world/CMakeLists.txt
@@ -27,7 +27,7 @@ add_executable(tst_world
     ../../src/database/database.cpp
     ../../src/database/datacache.cpp
     ../../src/database/queryexecutor.cpp
-    ../../src/database/db_adif_primary_subdvisions_data.cpp
+    ../../src/database/db_adif_primary_subdivisions_data.cpp
     ../../src/frequency.cpp
     ../../src/locator.cpp
     ../../src/adif.cpp
@@ -40,7 +40,7 @@ add_executable(tst_world
     ../../src/database/database.h
     ../../src/database/datacache.h
     ../../src/database/queryexecutor.h
-    ../../src/database/db_adif_primary_subdvisions_data.h
+    ../../src/database/db_adif_primary_subdivisions_data.h
     ../../src/frequency.h
     ../../src/qso.h
     ../../src/qsodatacache.h

--- a/tests/tst_world/tst_world.pro
+++ b/tests/tst_world/tst_world.pro
@@ -16,7 +16,7 @@ HEADERS += \
     ../../src/database/database.h \
     ../../src/database/datacache.h \
     ../../src/database/queryexecutor.h \
-    ../../src/database/db_adif_primary_subdvisions_data.h \
+    ../../src/database/db_adif_primary_subdivisions_data.h \
     ../../src/frequency.h \
     ../../src/qso.h \
     #../../src/qsodatacache.h \
@@ -33,7 +33,7 @@ SOURCES +=  tst_world.cpp \
     ../../src/database/database.cpp \
     ../../src/database/datacache.cpp \
     ../../src/database/queryexecutor.cpp \
-    ../../src/database/db_adif_primary_subdvisions_data.cpp \
+    ../../src/database/db_adif_primary_subdivisions_data.cpp \
     ../../src/frequency.cpp \
     ../../src/locator.cpp \
     ../../src/adif.cpp


### PR DESCRIPTION
## Summary
This PR removes the dark mode feature and simplifies palette management across the application by using Qt's `unsetPalette()` method instead of manually managing black/white text palettes.

## Key Changes

- **Removed dark mode infrastructure**: Deleted all dark mode toggle buttons, settings, and related UI from the setup dialog's color page
- **Simplified palette handling**: Replaced conditional palette assignments (palBlack/palWhite) with `unsetPalette()` calls to use system defaults for valid input states
- **Removed dark mode state management**: Eliminated `darkMode` boolean variables and `setDarkMode()` methods from:
  - `MainWindowInputQSO`
  - `MainWindowInputOthers`
  - `MainWindowMyDataTab`
  - `MainWindowSatTab`
  - `SetupPageColors`
  - `MainQSOEntryWidget`
  - `MainWindow`

- **Cleaned up settings**: Removed dark mode persistence from configuration files (DarkMode setting no longer saved/loaded)
- **Removed helper methods**: Deleted `readDarkMode()`, `getDarkMode()`, and related signal/slot connections throughout the codebase
- **Removed unused palettes**: Eliminated `palBlack` and `palWhite` palette objects, keeping only `palRed` for validation error states

## Implementation Details

- Input validation now uses a consistent pattern: valid inputs call `unsetPalette()` to restore default appearance, invalid inputs use `palRed` for error indication
- The application now relies on the system/application-wide palette for normal text colors instead of managing them per-widget
- Removed the `darkModeChanged` signal that was emitted from `SetupPageColors` and connected throughout the application

https://claude.ai/code/session_01RR2CidMv5V9znTPtUCtuu1