### PR TITLE
Add custom build_tests target to build all tests at once

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,14 @@
 enable_testing()
 
-# Add each test subdirectory (tst_* folders)
+# Collect all test executable names and add their subdirectories
 file(GLOB TEST_SUBDIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "tst_*")
+set(ALL_TEST_TARGETS "")
 foreach(subdir ${TEST_SUBDIRS})
     if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${subdir}")
         add_subdirectory(${subdir})
+        list(APPEND ALL_TEST_TARGETS ${subdir})
     endif()
 endforeach()
+
+# Custom target to build all tests at once: cmake --build build --target build_tests
+add_custom_target(build_tests DEPENDS ${ALL_TEST_TARGETS})


### PR DESCRIPTION
## Summary
This change adds a convenient CMake custom target that allows building all test executables in a single command, improving the developer workflow when working with multiple test subdirectories.

## Key Changes
- Track all test subdirectories in a new `ALL_TEST_TARGETS` list as they are added
- Create a custom `build_tests` target that depends on all collected test targets
- Users can now build all tests with: `cmake --build build --target build_tests`
- Updated comments to clarify the purpose of the test subdirectory collection logic

## Implementation Details
The solution leverages CMake's `add_custom_target()` with `DEPENDS` to create a meta-target that aggregates all individual test subdirectories. This provides a convenient alternative to building tests individually or using the default build target, making it easier to build only the test suite without building the entire project.

https://claude.ai/code/session_01NqecWdnoBVj9jyJ924pMBY