### PR TITLE
Refactor CMakeLists.txt: Improve Hamlib detection and test linking

### DIFF
--- a/tests/tst_hamlib/CMakeLists.txt
+++ b/tests/tst_hamlib/CMakeLists.txt
@@ -11,7 +11,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake")
 
 # 2. Find dependencies FIRST (before creating executables)
 find_package(Qt6 REQUIRED COMPONENTS Core Test Widgets)
-find_package(Hamlib REQUIRED)
 
 enable_testing()
 set(CMAKE_AUTOMOC ON)
@@ -19,44 +18,6 @@ set(CMAKE_AUTOMOC ON)
 # Collect test sources
 file(GLOB TEST_SOURCES "*.cpp")
 file(GLOB TEST_HEADERS "*.h")
-# Prefer a config package if available (e.g., Homebrew/macOS or user-provided)
-find_package (Hamlib REQUIRED)
-#find_package(Hamlib CONFIG QUIET)
-if(Hamlib_FOUND)
-    set(_hamlib_found TRUE)
-endif()
-
-# Try module mode (uses cmake/FindHamlib.cmake if present)
-if(NOT _hamlib_found)
-    find_package(Hamlib MODULE QUIET)
-    if(Hamlib_FOUND)
-        set(_hamlib_found TRUE)
-    endif()
-endif()
-
-# Linux-only fallback to pkg-config
-if(NOT _hamlib_found AND UNIX AND NOT APPLE)
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(HAMLIB REQUIRED IMPORTED_TARGET hamlib)
-    set(_hamlib_found TRUE)
-endif()
-
-# Link to whichever method was found
-if(TARGET Hamlib::Hamlib)
-    target_link_libraries(klog PRIVATE Hamlib::Hamlib)
-elseif(TARGET PkgConfig::HAMLIB)
-    target_link_libraries(klog PRIVATE PkgConfig::HAMLIB)
-elseif(HAMLIB_LIBRARIES)
-    target_include_directories(klog PRIVATE ${HAMLIB_INCLUDE_DIRS})
-    target_link_libraries(klog PRIVATE ${HAMLIB_LIBRARIES})
-else()
-    message(FATAL_ERROR
-        "Hamlib not found.\n"
-        "Linux: sudo apt install libhamlib-dev (or equivalent)\n"
-        "macOS: brew install hamlib (then set Hamlib_DIR or use FindHamlib.cmake)\n"
-        "Windows: install Hamlib and set Hamlib_DIR to its CMake package or provide libs/headers."
-    )
-endif()
 
 # 3. Create the test executable
 add_executable(tst_hamlib
@@ -81,16 +42,51 @@ add_executable(tst_hamlib
 # 4. Set Include Directories (Crucial for finding "hamlib/rig.h" and KLog headers)
 target_include_directories(tst_hamlib PRIVATE
     ../../src
-    ${Hamlib_INCLUDE_DIRS}
 )
 
-# 5. Link Libraries
-target_link_libraries(tst_hamlib PRIVATE
-    Qt6::Core
-    Qt6::Test
-    Qt6::Widgets
-    ${Hamlib_LIBRARIES} # Link the Hamlib binary found by find_package
-)
+# 5. Find and link Hamlib
+set(_hamlib_found FALSE)
+
+# Prefer a config package if available (e.g., Homebrew/macOS or user-provided)
+find_package(Hamlib CONFIG QUIET)
+if(Hamlib_FOUND)
+    set(_hamlib_found TRUE)
+endif()
+
+# Try module mode (uses cmake/FindHamlib.cmake if present)
+if(NOT _hamlib_found)
+    find_package(Hamlib MODULE QUIET)
+    if(Hamlib_FOUND)
+        set(_hamlib_found TRUE)
+    endif()
+endif()
+
+# Linux-only fallback to pkg-config
+if(NOT _hamlib_found AND UNIX AND NOT APPLE)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(HAMLIB REQUIRED IMPORTED_TARGET hamlib)
+    set(_hamlib_found TRUE)
+endif()
+
+set(_tst_libs Qt6::Core Qt6::Test Qt6::Widgets)
+
+if(TARGET Hamlib::Hamlib)
+    list(APPEND _tst_libs Hamlib::Hamlib)
+elseif(TARGET PkgConfig::HAMLIB)
+    list(APPEND _tst_libs PkgConfig::HAMLIB)
+elseif(HAMLIB_LIBRARIES)
+    target_include_directories(tst_hamlib PRIVATE ${HAMLIB_INCLUDE_DIRS})
+    list(APPEND _tst_libs ${HAMLIB_LIBRARIES})
+else()
+    message(FATAL_ERROR
+        "Hamlib not found.\n"
+        "Linux: sudo apt install libhamlib-dev (or equivalent)\n"
+        "macOS: brew install hamlib (then set Hamlib_DIR or use FindHamlib.cmake)\n"
+        "Windows: install Hamlib and set Hamlib_DIR to its CMake package or provide libs/headers."
+    )
+endif()
+
+target_link_libraries(tst_hamlib PRIVATE ${_tst_libs})
 
 # 6. Register the test
 add_test(NAME tst_hamlib COMMAND tst_hamlib)


### PR DESCRIPTION
## Summary
Refactored the test CMakeLists.txt to improve Hamlib dependency detection and linking logic. The changes reorganize the build configuration to be more robust and maintainable, with better separation of concerns between executable creation and dependency resolution.

## Key Changes
- **Reorganized build order**: Moved executable creation before Hamlib detection to establish the target early, then configure it with dependencies
- **Improved Hamlib detection**: Changed from `find_package(Hamlib REQUIRED)` to `find_package(Hamlib CONFIG QUIET)` with fallback mechanisms for better cross-platform compatibility
- **Centralized library management**: Introduced `_tst_libs` list to collect all dependencies before linking, making it easier to manage and modify linked libraries
- **Fixed target references**: Corrected linking from incorrect `klog` target to the actual `tst_hamlib` test target
- **Enhanced include directory handling**: Moved include directory configuration to occur before Hamlib detection, ensuring proper header resolution
- **Removed duplicate Hamlib search**: Eliminated redundant `find_package(Hamlib REQUIRED)` call that was immediately followed by conditional CONFIG search

## Notable Implementation Details
- The refactored code maintains all three Hamlib detection methods (CONFIG package, pkg-config, and manual variables) with proper fallback logic
- Include directories are now set once before dependency resolution, reducing redundancy
- The `_hamlib_found` flag is initialized before any detection attempts, providing clearer control flow
- All Qt6 components are consistently referenced through the centralized `_tst_libs` list

https://claude.ai/code/session_01CEF2fD9vFGjmaaRrYVWmFL