### PR TITLE
Prevent duplicate DXCC refresh during ADIF import

### DIFF
--- a/src/dxccstatuswidget.cpp
+++ b/src/dxccstatuswidget.cpp
@@ -384,19 +384,13 @@ void DXCCStatusWidget::setBands(const QString &_callingFunc, const QStringList &
     }
     bandNames = filterValidBands(sortedBands);
 
-   //qDebug() << Q_FUNC_INFO << " - 100";
-    fillData();
-    return;
     resetDXCCView();
     updateDXCCViewHeaders();
 
-   //qDebug() << Q_FUNC_INFO << " - 120";
     if (_creating)
     {
-       //qDebug() << Q_FUNC_INFO << " - 121";
         update();
     }
-   //qDebug() << Q_FUNC_INFO << " - END";
 
     emit debugLog(Q_FUNC_INFO, "End", Debug);
 }
@@ -455,9 +449,8 @@ void DXCCStatusWidget::slotRefreshButtonClicked()
     //qDebug() << Q_FUNC_INFO << " - Start";
 
     //TODO: Define a way to show the status of the selected log or all the logs in the DB
-    if (dxccView->rowCount()<1)
+    if (bandNames.isEmpty())
     {
-        //qDebug() << Q_FUNC_INFO << " - rowcount <1";
         return;
     }
     // qStringList _bands = bandNames;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2283,6 +2283,11 @@ void MainWindow::clearUIDX(bool _full)
 void MainWindow::slotRefreshDXCCWidget()
 {
     logEvent(Q_FUNC_INFO, "Start", Devel);
+    if (m_adifImporting)
+    {
+        logEvent(Q_FUNC_INFO, "END-skipped (adif import in progress)", Debug);
+        return;
+    }
     dxccStatusWidget->slotRefreshButtonClicked();
     logEvent(Q_FUNC_INFO, "END", Debug);
 }
@@ -3676,7 +3681,7 @@ void MainWindow::checkIfNewBandOrMode()
 
      //qDebug() << Q_FUNC_INFO << " - setting bands"  << QTime::currentTime().toString("hh:mm:ss") ;
     logEvent(Q_FUNC_INFO, "Setting bands", Debug);
-    dxccStatusWidget->setBands(Q_FUNC_INFO, bands, true);
+    dxccStatusWidget->setBands(Q_FUNC_INFO, bands, !m_adifImporting);
 
      //qDebug() << Q_FUNC_INFO << "  - currentBand: " << currentBand << QTime::currentTime().toString("hh:mm:ss") ;
     if (bands.contains(currentBand))
@@ -4514,12 +4519,13 @@ void MainWindow::slotADIFImport(){
             updateQSLRecAndSent();
             logWindow->refresh();
            //qDebug() << Q_FUNC_INFO << " -3";
+            m_adifImporting = true;
             checkIfNewBandOrMode();
            //qDebug() << Q_FUNC_INFO << " -4" ;
             awardsWidget->fillOperatingYears();
            //qDebug() << Q_FUNC_INFO << " -5" ;
+            m_adifImporting = false;
             slotShowAwards();
-            awardsWidget->showAwards();
            //qDebug() << Q_FUNC_INFO << " -6" ;
         }
         //qDebug() << Q_FUNC_INFO << " - 020";
@@ -5423,7 +5429,7 @@ void MainWindow::slotValidBandsReceived(const QStringList &_b)
 {
     logEvent(Q_FUNC_INFO, "Start", Devel);
      //qDebug() << Q_FUNC_INFO ;
-    dxccStatusWidget->setBands(Q_FUNC_INFO, _b, true);
+    dxccStatusWidget->setBands(Q_FUNC_INFO, _b, !m_adifImporting);
     satTabWidget->addBands(_b);
     mapWindow->setBands(_b);
      //qDebug() << Q_FUNC_INFO << " - END" ;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -669,6 +669,7 @@ private:
     bool configured, modify;
     bool needToEnd; // Just to control if the software needs to end.
     bool qrzAutoChanging; //To remove the data coming from QRZ.com only when data is coming.
+    bool m_adifImporting = false; // True while processing post-ADIF-import updates, to prevent double DXCC refresh
     QString mainQRZ, stationCallsign, operatorQRZ, dxLocator;
 
     int my_CQz, my_ITUz;


### PR DESCRIPTION
## Summary
This PR prevents duplicate DXCC widget refreshes that occur during ADIF import processing, which was causing performance issues and unnecessary UI updates.

## Key Changes
- Added `m_adifImporting` flag to track when post-ADIF-import updates are in progress
- Modified `slotRefreshDXCCWidget()` to skip refresh when ADIF import is active
- Updated `checkIfNewBandOrMode()` and `slotValidBandsReceived()` to pass the inverse of `m_adifImporting` flag to `setBands()`, preventing automatic UI updates during import
- Removed early return and `fillData()` call in `DXCCStatusWidget::setBands()` that was bypassing necessary view updates
- Changed `slotRefreshButtonClicked()` to check `bandNames.isEmpty()` instead of `dxccView->rowCount()` for more reliable empty state detection
- Removed redundant `awardsWidget->showAwards()` call from ADIF import flow

## Implementation Details
The flag is set to `true` before calling `checkIfNewBandOrMode()` and `fillOperatingYears()` during ADIF import, then set back to `false` afterward. This allows these functions to perform their necessary updates while preventing the DXCC widget from triggering redundant refresh operations that would occur through normal signal/slot connections.

https://claude.ai/code/session_01KppJuWd476zUGqk3zWaWoW