### PR TITLE
Fix map unavailability and suppress Qt debug noise

### DIFF
--- a/src/Changelog
+++ b/src/Changelog
@@ -7,6 +7,8 @@ TODO: LoTW import ensure exiting QSOs are updated
 
 
 TBD
+- Bugfix: Map shows "The geoservices provider is not supported" and crashes with a QGeoMapType binding error on platforms where the Qt6 Location OSM plugin is not installed (e.g. Raspberry Pi); map now shows a user-friendly "not available" overlay instead (Closes #447)
+- Bugfix: Verbose Qt6CTPlatformTheme palette/hint debug messages from the qt6ct platform theme no longer pollute the console output.
 - Bugfix: DXCluster spots not shown on map; callsign and status colour now displayed correctly (Closes #581)
 - Enhancement: Start time optimizations.
 - Enhancement: Split is now managed also from radio/UI.

--- a/src/Changelog
+++ b/src/Changelog
@@ -7,6 +7,7 @@ TODO: LoTW import ensure exiting QSOs are updated
 
 
 TBD
+- Bugfix: qmake6 printed spurious "using private headers" PROJECT MESSAGE warnings caused by the quickwidgets and location Qt modules; suppressed with no_private_qt_headers_warning.
 - Bugfix: Map shows "The geoservices provider is not supported" and crashes with a QGeoMapType binding error on platforms where the Qt6 Location OSM plugin is not installed (e.g. Raspberry Pi); map now shows a user-friendly "not available" overlay instead (Closes #447)
 - Bugfix: Verbose Qt6CTPlatformTheme palette/hint debug messages from the qt6ct platform theme no longer pollute the console output.
 - Bugfix: DXCluster spots not shown on map; callsign and status colour now displayed correctly (Closes #581)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,10 +35,22 @@
 #include <QSystemSemaphore>
 #include <QSharedMemory>
 #include <QMessageBox>
+#include <QLoggingCategory>
 #include "startwizard.h"
 #include "mainwindow.h"
 #include "utilities.h"
 #include <QElapsedTimer>
+
+// Suppress verbose debug noise from third-party Qt platform plugins (e.g. qt6ct)
+// that unconditionally call qDebug() for every palette/hint query.
+static void klogMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
+{
+    // Filter out the Qt6CTPlatformTheme palette/hint spam produced by qt6ct
+    if (msg.contains(QLatin1String("Qt6CTPlatformTheme")))
+        return;
+    // Forward everything else to Qt's default handler
+    qt_message_output(type, context, msg);
+}
 #ifdef KLOG_USE_VERSION_H
 #include "version.h"
 #endif
@@ -119,6 +131,7 @@ int main(int argc, char *argv[])
 {
     //qDebug() << Q_FUNC_INFO << " -  Start! ";
     //qDebug() << Q_FUNC_INFO << " -  " << QSslSocket::supportsSsl() << QSslSocket::sslLibraryBuildVersionString() << QSslSocket::sslLibraryVersionString();
+    qInstallMessageHandler(klogMessageHandler);
     QT_REQUIRE_VERSION(argc, argv, "6.0")
     //qDebug() << QT_VERSION_STR;
     QElapsedTimer timer;

--- a/src/qml/mapqmlfile.qml
+++ b/src/qml/mapqmlfile.qml
@@ -241,6 +241,41 @@ Rectangle {
 
     FocusScope { anchors.fill: parent }
 
+    // Shown when the Qt6 Location geo-services plugin (OSM) is not available.
+    // This prevents the "Unable to assign [undefined] to QGeoMapType" error
+    // and gives the user an actionable message instead of a blank/broken map.
+    Rectangle {
+        id: mapUnavailableOverlay
+        anchors.fill: parent
+        // Visible once the map component has initialised and reports no map types
+        visible: false
+        color: "#1e1e2e"
+        z: 200
+
+        Column {
+            anchors.centerIn: parent
+            spacing: 10
+
+            Text {
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: qsTr("Map not available")
+                color: "white"
+                font.bold: true
+                font.pixelSize: 18
+            }
+            Text {
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: qsTr("The Qt6 Location geo-services plugin is missing.\n" +
+                            "Install the OSM plugin for your platform, e.g.:\n" +
+                            "  Debian/Ubuntu/Raspberry Pi OS: apt install qml6-module-qtlocation\n" +
+                            "  or: apt install qt6-declarative-dev")
+                color: "#aaaaaa"
+                font.pixelSize: 12
+                horizontalAlignment: Text.AlignHCenter
+            }
+        }
+    }
+
     Plugin {
         id: mapPlugin
           name: "osm"
@@ -260,7 +295,9 @@ Rectangle {
         plugin: mapPlugin
         center: QtPositioning.coordinate(0, 0)
         zoomLevel: 4
-        activeMapType: supportedMapTypes[supportedMapTypes.length - 1]
+        // Note: activeMapType is set in Component.onCompleted to avoid
+        // "Unable to assign [undefined] to QGeoMapType" when the OSM plugin
+        // is not installed (e.g. Raspberry Pi without qt6-qtlocation plugins).
 
         // Helper: pan by screen pixels (dx, dy). Positive dx -> right, positive dy -> down.
         function panByPixels(dx, dy) {
@@ -340,7 +377,17 @@ Rectangle {
         onCenterChanged: function() {
             labelRebuildTimer.restart()
         }
-        Component.onCompleted: rebuildGridLabels()
+        Component.onCompleted: {
+            // Guard against empty supportedMapTypes (missing OSM plugin).
+            // Shows a user-friendly overlay instead of a QML binding error.
+            if (supportedMapTypes.length > 0) {
+                activeMapType = supportedMapTypes[supportedMapTypes.length - 1]
+                mapUnavailableOverlay.visible = false
+            } else {
+                mapUnavailableOverlay.visible = true
+            }
+            rebuildGridLabels()
+        }
 
         // =========================
         // Zoom controls (top-right)

--- a/src/src.pro
+++ b/src/src.pro
@@ -25,11 +25,14 @@
 # *****************************************************************************/
 QT += core gui
 QT += qml quick
-QT += quickwidgets
 
 CONFIG += c++11
 CONFIG += app_bundle
 CONFIG += static
+# Suppress the "using private headers" informational warning that Qt emits
+# when quickwidgets or location modules are used (they depend on Qt private
+# APIs internally; this is expected and does not affect the build).
+CONFIG += no_private_qt_headers_warning
 #CONFIG += console
 CONFIG -=depend_includepath
 #CONFIG += release

--- a/tests/tst_mainwindow/tst_mainwindow.pro
+++ b/tests/tst_mainwindow/tst_mainwindow.pro
@@ -12,6 +12,7 @@ QT += testlib \
 
 CONFIG += qt console warn_on depend_includepath testcase
 CONFIG -= app_bundle
+CONFIG += no_private_qt_headers_warning
 RESOURCES += ../../src/klog.qrc
 
 TEMPLATE = app

--- a/tests/tst_wizard/tst_wizard.pro
+++ b/tests/tst_wizard/tst_wizard.pro
@@ -12,6 +12,7 @@ QT += testlib \
 
 CONFIG += qt console warn_on depend_includepath testcase
 CONFIG -= app_bundle
+CONFIG += no_private_qt_headers_warning
 
 TEMPLATE = app
 


### PR DESCRIPTION
## Summary
This PR addresses three issues: graceful handling of missing Qt6 Location OSM plugin, suppression of verbose debug output from qt6ct platform theme, and elimination of spurious qmake warnings about private headers.

## Key Changes

- **Map unavailability handling**: Added a user-friendly overlay that displays when the Qt6 Location geo-services plugin is not available (e.g., on Raspberry Pi). The overlay explains the issue and provides installation instructions instead of showing a blank/broken map or QML binding errors.
  - Deferred `activeMapType` assignment to `Component.onCompleted` to avoid "Unable to assign [undefined] to QGeoMapType" errors
  - Added guard check for empty `supportedMapTypes` array
  - Created `mapUnavailableOverlay` Rectangle with helpful error message

- **Debug output suppression**: Implemented a custom message handler in `main.cpp` that filters out verbose Qt6CTPlatformTheme palette/hint debug spam from the qt6ct platform theme while preserving other debug output.

- **Build warning suppression**: 
  - Added `no_private_qt_headers_warning` CONFIG flag to suppress qmake warnings about private header usage from quickwidgets and location modules
  - Removed unused `quickwidgets` from QT dependencies in src.pro
  - Applied the same CONFIG flag to test projects for consistency

- **Documentation**: Updated Changelog with descriptions of all three bugfixes

## Implementation Details

The map overlay uses a dark background (#1e1e2e) with centered text providing clear instructions for users. The visibility is controlled by checking `supportedMapTypes.length` at component initialization, ensuring the overlay only appears when the plugin is genuinely missing rather than during normal operation.

https://claude.ai/code/session_01Kj6RpMtoJ4zb1CDF5VHcMg