### PR TITLE
Reorganize test subdirs and remove hamlib dependencies from elogclublog test

### DIFF
--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -30,32 +30,28 @@
 
 TEMPLATE=subdirs
 SUBDIRS=\
-   tst_dxcluster \
-   tst_wizard \
    tst_adif \
    tst_callsign \
-   tst_dxspot \
-   tst_frequency \
-   tst_utilities \
-   tst_mainqsoentrywidget \
-   tst_mainwindowsattab \
-   tst_dataproxy \
-   tst_database \
    tst_datacache \
+   tst_database \
+   tst_dataproxy \
    tst_dxcluster \
    tst_dxspot \
    tst_elogclublog \
    tst_filemanager \
+   tst_frequency \
    tst_hamlib \
    tst_locator \
    tst_logwindow \
    tst_mainqsoentrywidget \
    tst_mainwindow \
-   tst_mainwindowinputqso \
    tst_mainwindowinputothers \
+   tst_mainwindowinputqso \
    tst_mainwindowsattab \
    tst_qso \
    tst_setuphamlibnetworkwidget \
    tst_setuphamlibserialwidget \
    tst_setuppageelog \
+   tst_utilities \
+   tst_wizard \
    tst_world

--- a/tests/tst_elogclublog/tst_elogclublog.pro
+++ b/tests/tst_elogclublog/tst_elogclublog.pro
@@ -63,29 +63,13 @@ unix:!mac {
     message(unix:!mac)
     DEFINES += APP_LINUX
     QMAKE_CXXFLAGS += -fmessage-length=0
-
-    INSTALLS += datafiles
-    LIBS += -lhamlib
 }
 
 macx: {
     message(macx)
-    INCLUDEPATH +=/usr/local/include/
-    LIBS += -L"/usr/local/lib" -lhamlib
 }
 
 win32: {
     message(windows)
-    contains(QT_ARCH, i386) {
-        message("32-bit")
-        LIBS += -L"$$PWD/../../libs/win32/hamlib/lib/gcc" -lhamlib
-        LIBS += -L"$$PWD/../../libs/win32/hamlib/bin"
-        INCLUDEPATH += "$$PWD/../../libs/win32/hamlib/include/"
-    } else {
-        message("64-bit")
-        LIBS += -L"$$PWD/../../libs/win64/hamlib/lib/gcc" -lhamlib
-        LIBS += -L"$$PWD/../../libs/win64/hamlib/bin"
-        INCLUDEPATH += "$$PWD/../../libs/win64/hamlib/include/"
-    }
 }
 


### PR DESCRIPTION
## Summary
This PR reorganizes the test subdirectories in alphabetical order and removes platform-specific hamlib library configurations from the elogclublog test project file.

## Key Changes
- **Test subdirectories**: Sorted the SUBDIRS list in `tests/tests.pro` alphabetically for better maintainability and consistency
- **Hamlib dependencies**: Removed all hamlib-related library paths, include paths, and installation rules from `tst_elogclublog.pro`:
  - Removed `INSTALLS += datafiles` from Unix/Linux configuration
  - Removed hamlib LIBS and INCLUDEPATH settings from macOS configuration
  - Removed platform-specific (32-bit/64-bit) hamlib library configurations from Windows build

## Implementation Details
The elogclublog test no longer requires hamlib as a direct dependency, simplifying the build configuration and reducing platform-specific conditional compilation logic. The test subdirectories are now maintained in alphabetical order, making it easier to locate and manage individual test modules.

https://claude.ai/code/session_01JxdT2ZA3GDzxiAMD5whPSi