### PR TITLE
Fix DXCluster password not sent to server after callsign

### DIFF
--- a/src/Changelog
+++ b/src/Changelog
@@ -7,6 +7,7 @@ TODO: LoTW import ensure exiting QSOs are updated
 
 
 TBD
+- Bugfix: DXCluster password not sent to server after callsign (Closes #829)
 - Bugfix: qmake6 printed spurious "using private headers" PROJECT MESSAGE warnings caused by the quickwidgets and location Qt modules; suppressed with no_private_qt_headers_warning.
 - Bugfix: Map shows "The geoservices provider is not supported" and crashes with a QGeoMapType binding error on platforms where the Qt6 Location OSM plugin is not installed (e.g. Raspberry Pi); map now shows a user-friendly "not available" overlay instead (Closes #447)
 - Bugfix: Verbose Qt6CTPlatformTheme palette/hint debug messages from the qt6ct platform theme no longer pollute the console output.

--- a/src/dxcluster/dxcluster.cpp
+++ b/src/dxcluster/dxcluster.cpp
@@ -158,6 +158,17 @@ void DXClusterWidget::setMyQRZ(const QString &_qrz)
     }
 }
 
+// static
+QString DXClusterWidget::buildAuthSequence(const QString &callsign, const QString &password)
+{
+    if (callsign.isEmpty())
+        return {};
+    QString seq = callsign + '\n';
+    if (!password.isEmpty())
+        seq += password + '\n';
+    return seq;
+}
+
 void DXClusterWidget::addData()
 {
    //qDebug() << Q_FUNC_INFO;
@@ -473,8 +484,9 @@ void DXClusterWidget::slotClusterSocketConnected()
         }
 
         QTextStream os(tcpSocket);
-        if (!callsignText.isEmpty()) {
-            os << callsignText << "\n";
+        const QString authSeq = buildAuthSequence(callsignText, passwordText);
+        if (!authSeq.isEmpty()) {
+            os << authSeq;
             sendButton->setText(tr("Disconnect"));
             clearButton->setText(tr("Clear"));
             dxClusterAlreadyConnected = true;

--- a/src/dxcluster/dxcluster.h
+++ b/src/dxcluster/dxcluster.h
@@ -109,6 +109,7 @@ private:
     bool openFile();
     QString cleanSpotter(const QString _call);
     void addData(); //TO BE DELETED, JUST FOR TESTING PURPOSES
+    static QString buildAuthSequence(const QString &callsign, const QString &password);
 
     QTcpSocket *tcpSocket = nullptr;
     QListWidget *dxClusterListWidget;

--- a/tests/tst_dxcluster/tst_dxcluster.cpp
+++ b/tests/tst_dxcluster/tst_dxcluster.cpp
@@ -136,6 +136,12 @@ private slots:
     void test_locatorFallback_entityLocatorValidForKnownCall();
     void test_locatorPrimary_getQRZLocatorValidForKnownCall();
 
+    // O) buildAuthSequence — regression for issue #829
+    //    Password must be included in the auth sequence sent to the cluster.
+    void test_buildAuthSequence_callsignOnly();
+    void test_buildAuthSequence_callsignAndPassword();
+    void test_buildAuthSequence_emptyCallsign();
+
 private:
     // Helper: build an EntityStatus with the given QSOStatus and bandId=-1.
     // bandId=-1 guarantees that no band-based filter can interfere with the
@@ -647,6 +653,35 @@ void tst_DXCluster::test_locatorPrimary_getQRZLocatorValidForKnownCall()
              "getQRZLocator must return a non-empty locator for a known callsign");
     QVERIFY2(locator.isValidLocator(primaryLocator),
              "getQRZLocator must return a valid Maidenhead locator for a known callsign");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// O) buildAuthSequence — regression for issue #829
+//    Before the fix, slotClusterSocketConnected() collected the password but
+//    never sent it to the server.  buildAuthSequence() encapsulates the logic
+//    so it can be tested without a live TCP socket or QInputDialog.
+// ─────────────────────────────────────────────────────────────────────────────
+
+void tst_DXCluster::test_buildAuthSequence_callsignOnly()
+{
+    // No password → only the callsign line should be produced.
+    const QString result = DXClusterWidget::buildAuthSequence("EA4K", "");
+    QCOMPARE(result, QString("EA4K\n"));
+}
+
+void tst_DXCluster::test_buildAuthSequence_callsignAndPassword()
+{
+    // With a password → callsign line followed by password line.
+    // This is the scenario that was broken in issue #829.
+    const QString result = DXClusterWidget::buildAuthSequence("EA4K", "s3cr3t");
+    QCOMPARE(result, QString("EA4K\ns3cr3t\n"));
+}
+
+void tst_DXCluster::test_buildAuthSequence_emptyCallsign()
+{
+    // Empty callsign → nothing should be sent (connection stays unauthenticated).
+    const QString result = DXClusterWidget::buildAuthSequence("", "somepassword");
+    QVERIFY(result.isEmpty());
 }
 
 QTEST_MAIN(tst_DXCluster)


### PR DESCRIPTION
## Summary
Fixes issue #829 where the DXCluster password was collected but never sent to the server during authentication. The fix extracts the authentication sequence logic into a testable static method and ensures both callsign and password are transmitted.

## Key Changes
- **New static method `buildAuthSequence()`**: Encapsulates the logic for building the authentication sequence sent to the DXCluster server. Returns a string containing the callsign and password (if provided), each on a separate line. Returns empty string if callsign is empty.
- **Updated `slotClusterSocketConnected()`**: Now uses `buildAuthSequence()` to construct the full authentication sequence including the password, fixing the regression where only the callsign was sent.
- **Added regression tests**: Three new test cases verify the authentication sequence behavior:
  - `test_buildAuthSequence_callsignOnly()`: Validates callsign-only authentication
  - `test_buildAuthSequence_callsignAndPassword()`: Validates the fixed scenario with both callsign and password
  - `test_buildAuthSequence_emptyCallsign()`: Validates that empty callsigns produce no output
- **Updated Changelog**: Documented the bugfix

## Implementation Details
The `buildAuthSequence()` method follows a simple logic:
1. Returns empty string if callsign is empty (prevents unauthenticated connections)
2. Builds sequence with callsign followed by newline
3. Appends password and newline if password is not empty
4. Returns the complete sequence for transmission to the server

This approach makes the authentication logic testable without requiring a live TCP socket or user input dialog.

https://claude.ai/code/session_011DQX4cVvHXHAsn4UEQQ6hW