### PR TITLE
Fix duplicate QSO detection by using parent mode for cache lookup

### DIFF
--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -969,8 +969,16 @@ int FileManager::processQSO(QSO& qso, const QString& _stationCallsign)
     if (bandId <= 0)
         return -1;
 
+    // Validate the mode/submode: accepts submode names like "USB", "FT4" (e.g. from LoTW ADIF)
     const QString modeToFind = qso.getSubmode().isEmpty() ? qso.getMode() : qso.getSubmode();
-    const int modeId = dataProxy->getIdFromModeName(modeToFind);
+    if (dataProxy->getIdFromModeName(modeToFind) <= 0)
+        return -3;
+
+    // Mode ID for duplicate cache lookup: always use the parent mode, consistent with
+    // what bindQSOValues stores in the DB (getIdFromModeName(qso.getMode())).
+    // Using the submode here caused cache misses when LoTW sends submodes (e.g. SSB+USB,
+    // MFSK+FT4) whose IDs differ from the stored parent mode ID, producing duplicate QSOs.
+    const int modeId = dataProxy->getIdFromModeName(qso.getMode());
     if (modeId <= 0)
         return -3;
 


### PR DESCRIPTION
## Summary
Fixed an issue where QSOs from LoTW with submode information (e.g., "USB", "FT4") were incorrectly identified as duplicates because the duplicate cache lookup was using submode IDs instead of parent mode IDs.

## Key Changes
- Added validation to ensure the mode/submode lookup returns a valid ID before proceeding
- Changed the duplicate cache lookup to always use the parent mode ID (`qso.getMode()`) instead of the submode ID
- This ensures consistency with what `bindQSOValues` stores in the database, which uses the parent mode ID

## Implementation Details
The fix addresses a cache miss scenario where LoTW sends QSOs with submodes (e.g., "SSB+USB", "MFSK+FT4") whose IDs differ from the parent mode IDs stored in the database. By using the parent mode for the duplicate lookup, the cache now correctly identifies these as existing QSOs rather than creating duplicates.

The validation check for mode/submode lookup was also added as a safety measure to return early with error code -3 if the mode cannot be resolved.

https://claude.ai/code/session_01H9SF5QvNWhsEd54AENjP62