### PR TITLE
Set default value for SendEQSLByDefault setting

### DIFF
--- a/src/setuppages/setuppagemisc.cpp
+++ b/src/setuppages/setuppagemisc.cpp
@@ -646,7 +646,7 @@ void SetupPageMisc::loadSettings(const QString &_callingFunction)
     completeWithPreviousCheckBox->setChecked (settings.value("CompleteWithPrevious").toBool ());
     checkNewVersionCheckBox->setChecked (settings.value("CheckNewVersions").toBool ());
     useDxMarathonCheckBox->setChecked (settings.value("ManageDXMarathon").toBool ());
-    sendEQSLByDefaultSearchCheckBox->setChecked (settings.value("SendEQSLByDefault").toBool ());
+    sendEQSLByDefaultSearchCheckBox->setChecked (settings.value("SendEQSLByDefault", true).toBool ());
     deleteAlwaysAdiFileCheckBox->setChecked (settings.value("DeleteAlwaysAdiFile").toBool ());
     checkCallsCheckBox->setChecked (settings.value("CheckValidCalls").toBool ());
     //provideCallCheckBox->setChecked (settings.value("ProvideInfo").toBool ());


### PR DESCRIPTION
## Summary
Updated the settings loading logic to provide a default value when the "SendEQSLByDefault" setting is not found in the configuration.

## Changes
- Modified `SetupPageMisc::loadSettings()` to supply a default value of `true` for the "SendEQSLByDefault" setting
- Changed from `settings.value("SendEQSLByDefault")` to `settings.value("SendEQSLByDefault", true)`

## Details
This change ensures that the "Send EQSL by default" checkbox will be checked by default if the setting has not been previously configured. Previously, if the setting was missing, it would default to `false` (unchecked). This provides a better user experience by establishing a sensible default behavior for new installations or users without existing preferences.

https://claude.ai/code/session_01Jwh3nkbY8cxKjHN4Q44jdB