### PR TITLE
Fix column visibility toggle for relational table model fields

### DIFF
--- a/src/logwindow.cpp
+++ b/src/logwindow.cpp
@@ -232,7 +232,10 @@ void LogWindow::setColumnsOfLog(const QStringList &_columns)
 void LogWindow::showColumn(const QString &_columnName)
 {
     //qDebug() << Q_FUNC_INFO << " - Start";
-    int col = logModel->record().indexOf(_columnName);
+    // Use the raw table schema to find the column index. After QSqlRelationalTableModel::setRelation()
+    // is called for bandid/modeid, record() renames those fields to the display column from the
+    // related table (e.g. "name", "submode"), so record().indexOf("bandid") would return -1.
+    int col = QSqlDatabase::database().record("log").indexOf(_columnName);
     if (col >= 0)
         logView->setColumnHidden(col, false);
 

--- a/src/logwindow.h
+++ b/src/logwindow.h
@@ -31,6 +31,7 @@
 #include <QWidget>
 #include <QTableView>
 #include <QAction>
+#include <QSqlDatabase>
 #include <QSqlQuery>
 #include <QSqlRecord>
 #include <QSqlRelationalDelegate>


### PR DESCRIPTION
## Summary
Fixed an issue where toggling column visibility for relational fields (bandid, modeid) in the log window would fail silently due to the QSqlRelationalTableModel renaming those fields to their display columns.

## Key Changes
- Modified `LogWindow::showColumn()` to query the raw table schema instead of the model's record when looking up column indices
- Changed from `logModel->record().indexOf(_columnName)` to `QSqlDatabase::database().record("log").indexOf(_columnName)`
- Added `#include <QSqlDatabase>` header to support direct database schema queries

## Implementation Details
When `QSqlRelationalTableModel::setRelation()` is called for fields like "bandid" and "modeid", the model's `record()` method returns renamed fields (e.g., "name", "submode") from the related tables instead of the original column names. This caused `record().indexOf("bandid")` to return -1, preventing the column visibility toggle from working.

By querying the raw table schema directly from the database, we bypass the model's field renaming and correctly locate the actual table columns, allowing the visibility toggle to function as intended.

https://claude.ai/code/session_01R2mGBAJ1jTjo6YEwLAW8Fs