### PR TITLE
Update entity status with QSO award status on band/mode changes

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1007,6 +1007,7 @@ void MainWindow::slotBandChanged (const QString &_b)
        //qDebug() << "MainWindow:: - calling showStatusOfDXCC-02 " ;
     if (currentEntity>0)
     {
+        _entityStatus.status = awards.getQSOStatus(_entityStatus.dxcc, _entityStatus.bandId, _entityStatus.modeId);
         showStatusOfDXCC(_entityStatus);
     }
     changingBand = false;
@@ -1035,6 +1036,7 @@ void MainWindow::slotModeChanged (const QString &_m)
     _entityStatus.modeId    = currentModeShown;
     _entityStatus.logId     = currentLog;
 
+    _entityStatus.status    = awards.getQSOStatus(_entityStatus.dxcc, _entityStatus.bandId, _entityStatus.modeId);
     showStatusOfDXCC(_entityStatus);
     if (!modify)
     {
@@ -4648,6 +4650,7 @@ void MainWindow::qsoToEdit (const int _qso)
     _entityStatus.logId     = currentLog;
 
    //qDebug() << Q_FUNC_INFO << " - in default - 104"  ;
+    _entityStatus.status    = awards.getQSOStatus(_entityStatus.dxcc, _entityStatus.bandId, _entityStatus.modeId);
     showStatusOfDXCC(_entityStatus);
 
     readingTheUI = false;
@@ -5172,6 +5175,7 @@ void MainWindow::slotAnalyzeDxClusterSignal(const DXSpot &_spot)
         //(ql.at(1)).toDouble()
         _entityStatus.bandId = dataProxy->getBandIdFromFreq((spot.getFrequency().toDouble()));
         // qls << QRZ << BandId << ModeId << lognumber;
+        _entityStatus.status = awards.getQSOStatus(_entityStatus.dxcc, _entityStatus.bandId, _entityStatus.modeId);
         showStatusOfDXCC(_entityStatus);
     }
     else if (spot.getClickStatus() == DoubleClick)


### PR DESCRIPTION
## Summary
This change ensures that the entity status is properly updated with the current QSO award status whenever the band, mode, or edited QSO changes. Previously, the status field was not being refreshed in these scenarios, which could lead to stale or incorrect award status information being displayed.

## Key Changes
- Added `_entityStatus.status` update in `slotBandChanged()` to refresh status when band selection changes
- Added `_entityStatus.status` update in `slotModeChanged()` to refresh status when mode selection changes
- Added `_entityStatus.status` update in `qsoToEdit()` to refresh status when editing a QSO
- Added `_entityStatus.status` update in `slotAnalyzeDxClusterSignal()` to refresh status when analyzing DX cluster spots

All updates call `awards.getQSOStatus()` with the current DXCC entity, band ID, and mode ID before displaying the entity status.

## Implementation Details
The fix is consistent across all four locations, using the same pattern:
```cpp
_entityStatus.status = awards.getQSOStatus(_entityStatus.dxcc, _entityStatus.bandId, _entityStatus.modeId);
showStatusOfDXCC(_entityStatus);
```

This ensures the award status is always current before being shown to the user, preventing display of outdated information when context changes.

https://claude.ai/code/session_01MDqFANMGdUssm5J8KxseEx