### PR TITLE
Refactor dark mode loading to use setupDialog

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -6374,8 +6374,6 @@ bool MainWindow::loadSettings()
     workedColor = settings.value("WorkedColor").value<QColor>();
     confirmedColor = settings.value("ConfirmedColor").value<QColor>();
     defaultColor = settings.value("DefaultColor").value<QColor>();
-    bool darkMode = settings.value("DarkMode", false).toBool ();
-
    //qDebug() << Q_FUNC_INFO << " - NewOneColor:    " << newOneColor.name(QColor::HexRgb);
    //qDebug() << Q_FUNC_INFO << " - NewOneColor:    " << newOneColor.name();
    //qDebug() << Q_FUNC_INFO << " - NeededColor:    " << neededColor.name(QColor::HexRgb);
@@ -6386,7 +6384,7 @@ bool MainWindow::loadSettings()
     settings.endGroup ();
     setColors(newOneColor, neededColor, workedColor, confirmedColor, defaultColor);
 
-    setDarkMode(darkMode);
+    setupDialog->loadDarkMode();
 
       //qDebug() << Q_FUNC_INFO << " - 70 - misc";
     settings.beginGroup ("Misc");


### PR DESCRIPTION
## Summary
Refactored the dark mode initialization logic in `MainWindow::loadSettings()` to delegate the responsibility to the setup dialog instead of handling it directly in the main window.

## Key Changes
- Removed the local `darkMode` variable that was reading from settings
- Replaced the direct `setDarkMode(darkMode)` call with `setupDialog->loadDarkMode()`
- This moves the dark mode loading logic to be managed by the setup dialog component

## Implementation Details
The change shifts the dark mode initialization from the main window's settings loading routine to the setup dialog's own loading method. This suggests a refactoring toward better separation of concerns, where the setup dialog is now responsible for managing its own dark mode state rather than having the main window coordinate it.

https://claude.ai/code/session_01FQdFA7S76vqrmpuj3utKiY