### PR TITLE
Force radio status refresh when exiting manual mode

### DIFF
--- a/src/Changelog
+++ b/src/Changelog
@@ -16,6 +16,7 @@ Mar 2026 - 2.5
 - Enhancement: Complete ADIF->IsValidWWFF (Closes #718)
 - Enhancement: List view fields order and sorting (Closes #678)
 - Enhancement: Created a QHash to speed up the execution reducing database access.
+- Bugfix: KLog does not follow the radio in read mode when leaving manual mode (Closes #417)
 - Bugfix: DXCluster password not sent to server after callsign (Closes #829)
 - Bugfix: qmake6 printed spurious "using private headers" PROJECT MESSAGE warnings caused by the quickwidgets and location Qt modules; suppressed with no_private_qt_headers_warning.
 - Bugfix: Map shows "The geoservices provider is not supported" and crashes with a QGeoMapType binding error on platforms where the Qt6 Location OSM plugin is not installed (e.g. Raspberry Pi); map now shows a user-friendly "not available" overlay instead (Closes #447)

--- a/src/hamlibclass.cpp
+++ b/src/hamlibclass.cpp
@@ -324,6 +324,15 @@ bool HamLibClass::readRadio()
     return readRadioInternal();
 }
 
+void HamLibClass::forceRead()
+{
+    // Reset cached status so the next read always emits radioStatusChanged,
+    // even if the radio values haven't changed since the last poll.
+    logEvent(Q_FUNC_INFO, "Start", Devel);
+    radioStatus = RadioStatus();
+    readRadioInternal();
+}
+
 bool HamLibClass::readRadioInternal()
 {
     logEvent(Q_FUNC_INFO, "Start", Devel);

--- a/src/hamlibclass.h
+++ b/src/hamlibclass.h
@@ -88,6 +88,7 @@ public:
     bool init(bool _active);
     bool stop();
     bool readRadio();
+    void forceRead();
     bool isRunning();
     void initClass();
     void clean();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -6067,9 +6067,12 @@ void MainWindow::slotManualMode(bool _enable)
 {
       //qDebug() << Q_FUNC_INFO << ": " << util->boolToQString (_enable);
     manualMode = _enable;
-    if ((manualMode) && (hamlibActive))
+    if ((!manualMode) && (hamlibActive))
     {
-        hamlib->readRadio();
+        // Exiting manual mode: force a radio read and always emit the current
+        // status so the UI updates immediately, even if the radio values
+        // didn't change while polling was being ignored.
+        hamlib->forceRead();
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds a mechanism to force a radio status refresh and ensure UI updates when exiting manual mode, even if the underlying radio values haven't changed.

## Key Changes
- Added `forceRead()` method to `HamLibClass` that resets the cached radio status before reading, ensuring the `radioStatusChanged` signal is always emitted
- Modified `slotManualMode()` in `MainWindow` to call `forceRead()` instead of `readRadio()` when exiting manual mode
- Fixed the condition logic in `slotManualMode()` from `(manualMode)` to `(!manualMode)` to correctly trigger on mode exit rather than entry

## Implementation Details
The `forceRead()` method clears the cached `radioStatus` object before calling `readRadioInternal()`. This ensures that even if the radio's current state matches the previously cached state, the status change signal will still be emitted, allowing the UI to refresh immediately when manual mode is disabled and polling resumes.

https://claude.ai/code/session_01DjWuwLbZ4YwWzhPu7PK5D4