### PR TITLE
Add database path injection to DataProxy_SQLite constructor

### DIFF
--- a/src/dataproxy_sqlite.cpp
+++ b/src/dataproxy_sqlite.cpp
@@ -68,6 +68,21 @@ DataProxy_SQLite::DataProxy_SQLite(const QString &_parentFunction, const QString
     logEvent (Q_FUNC_INFO, "END", Debug);
 }
 
+DataProxy_SQLite::DataProxy_SQLite(const QString &_parentFunction, const QString &_softVersion, const QString &_dbPath)
+{
+    (void)_parentFunction;
+    logLevel = None;
+    util = new Utilities(Q_FUNC_INFO);
+    util->setVersion(_softVersion);
+    db = new DataBase(Q_FUNC_INFO, _softVersion, _dbPath);
+    dbCreated = db->createConnection(Q_FUNC_INFO);
+    createHashes();
+    searching = false;
+    executionN = 0;
+    connect(db, SIGNAL(debugLog(QString, QString, DebugLogLevel)), this, SLOT(slotCaptureDebugLogs(QString, QString, DebugLogLevel)));
+    logEvent(Q_FUNC_INFO, "END", Debug);
+}
+
 DataProxy_SQLite::~DataProxy_SQLite()
 {
     logEvent (Q_FUNC_INFO, "Start", Debug);

--- a/src/dataproxy_sqlite.h
+++ b/src/dataproxy_sqlite.h
@@ -66,6 +66,7 @@ class DataProxy_SQLite : public QObject
 
 public:
     DataProxy_SQLite(const QString &_parentFunction, const QString &_softVersion="0.0");
+    DataProxy_SQLite(const QString &_parentFunction, const QString &_softVersion, const QString &_dbPath);
     ~DataProxy_SQLite();
     void setLogLevel (const DebugLogLevel _l);
     QString getSoftVersion();

--- a/tests/tst_dataproxy/tst_dataproxy.cpp
+++ b/tests/tst_dataproxy/tst_dataproxy.cpp
@@ -87,61 +87,12 @@ void tst_DataProxy::initTestCase()
 {
     // Remove any leftover DB from a previous crashed run
     if (QFile::exists(testDbPath))
-    {
-        QVERIFY2(QFile::remove(testDbPath),
-                 "Could not remove leftover test database");
-    }
+        QFile::remove(testDbPath);
 
     util = new Utilities(Q_FUNC_INFO);
 
-    // DataProxy_SQLite reads the DB path from Utilities::getKLogDBFile(), which
-    // in turn reads QSettings.  We override that by pointing QSettings at a
-    // temporary config that redirects the DB to our temp path.
-    // The cleanest way that does NOT touch user settings is to create the
-    // DataBase directly and hand it a known path.  DataProxy_SQLite exposes no
-    // such injection, so we use the same trick as tst_database: pass the path
-    // via a fresh Utilities object that writes it into a temp config.
-    //
-    // Simplest approach that works with the existing API: just redirect the DB
-    // file by creating the DataBase ourselves and replacing the file before
-    // DataProxy_SQLite opens it.  We do this by writing a minimal temp config
-    // that points DBPath at our temp dir.
-
-    QString tempCfg = QDir::tempPath() + "/tst_dataproxy_klogrc";
-    QSettings settings(tempCfg, QSettings::IniFormat);
-    settings.beginGroup("Misc");
-    settings.setValue("DBPath", QDir::tempPath() + "/");
-    settings.endGroup();
-    settings.sync();
-
-    // util->getCfgFile() is used internally – we cannot override it without
-    // subclassing Utilities. The simplest working solution is to pass the
-    // full DB path directly to DataBase and bypass DataProxy_SQLite's own
-    // construction, OR just accept the default path but use a DIFFERENT file
-    // name that we delete afterwards.
-    //
-    // Since the DataProxy_SQLite constructor always calls
-    //   db = new DataBase(Q_FUNC_INFO, version, util->getKLogDBFile())
-    // and getKLogDBFile() returns  <homeDir>/logbook.dat, we instead create
-    // the proxy with a version string that makes getKLogDBFile() resolve to
-    // our temp path by temporarily replacing the DB file name.
-    //
-    // The most practical solution given the current architecture: create the
-    // DataProxy using the standard path, but rename/restore the real DB around
-    // the test so we never corrupt user data.
-
-    QString realDbPath = util->getKLogDBFile();  // e.g. ~/.klog/logbook.dat
-    QString backupPath = realDbPath + ".tst_backup";
-
-    // If a real DB exists, back it up
-    if (QFile::exists(realDbPath))
-    {
-        QVERIFY2(QFile::rename(realDbPath, backupPath),
-                 "Could not back up the real user database");
-    }
-
-    // Now DataProxy_SQLite will create a FRESH database at realDbPath
-    dataProxy = new DataProxy_SQLite(Q_FUNC_INFO, "1.5");
+    // Use a dedicated temp DB — never touches the real user database
+    dataProxy = new DataProxy_SQLite(Q_FUNC_INFO, "1.5", testDbPath);
     QVERIFY2(dataProxy != nullptr, "DataProxy could not be created");
 
     // Create log #1 so QSOs can be inserted in test_addQSO
@@ -153,21 +104,11 @@ void tst_DataProxy::initTestCase()
 
 void tst_DataProxy::cleanupTestCase()
 {
-    // Close connections before deleting files
     delete dataProxy;
     dataProxy = nullptr;
 
-    Utilities tmpUtil(Q_FUNC_INFO);
-    QString realDbPath  = tmpUtil.getKLogDBFile();
-    QString backupPath  = realDbPath + ".tst_backup";
-
-    // Remove the test database
-    if (QFile::exists(realDbPath))
-        QFile::remove(realDbPath);
-
-    // Restore the real user database if it was backed up
-    if (QFile::exists(backupPath))
-        QFile::rename(backupPath, realDbPath);
+    if (QFile::exists(testDbPath))
+        QFile::remove(testDbPath);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/tst_filemanager/tst_filemanager.cpp
+++ b/tests/tst_filemanager/tst_filemanager.cpp
@@ -61,8 +61,7 @@ private:
     World *world;
     Utilities *util;
     QString version;
-    QString realDbPath;
-    QString backupPath;
+    QString testDbPath;
     QString adifFilePath;
 };
 
@@ -70,6 +69,7 @@ tst_FileManager::tst_FileManager()
     : dataProxy(nullptr), fileManager(nullptr), world(nullptr), util(nullptr)
 {
     version = "1.5";
+    testDbPath = QDir::tempPath() + "/tst_filemanager_logbook.dat";
 }
 
 tst_FileManager::~tst_FileManager(){}
@@ -77,15 +77,13 @@ tst_FileManager::~tst_FileManager(){}
 void tst_FileManager::initTestCase()
 {
     util = new Utilities(Q_FUNC_INFO);
-    realDbPath = util->getKLogDBFile();
-    backupPath = realDbPath + ".tst_fm_backup";
 
-    // Back up any existing real DB so we don't corrupt user data
-    if (QFile::exists(realDbPath))
-        QVERIFY2(QFile::rename(realDbPath, backupPath), "Could not back up real user database");
+    // Remove any leftover DB from a previous crashed run
+    if (QFile::exists(testDbPath))
+        QFile::remove(testDbPath);
 
-    // DataProxy_SQLite will create a fresh DB at realDbPath
-    dataProxy = new DataProxy_SQLite(Q_FUNC_INFO, version);
+    // Use a dedicated temp DB — never touches the real user database
+    dataProxy = new DataProxy_SQLite(Q_FUNC_INFO, version, testDbPath);
     QVERIFY2(dataProxy != nullptr, "DataProxy could not be created");
 
     // Create log #1 so ADIF import has a valid target log
@@ -116,11 +114,8 @@ void tst_FileManager::cleanupTestCase()
     if (!adifFilePath.isEmpty() && QFile::exists(adifFilePath))
         QFile::remove(adifFilePath);
 
-    if (QFile::exists(realDbPath))
-        QFile::remove(realDbPath);
-
-    if (QFile::exists(backupPath))
-        QFile::rename(backupPath, realDbPath);
+    if (QFile::exists(testDbPath))
+        QFile::remove(testDbPath);
 }
 
 QString tst_FileManager::createADIFFile()


### PR DESCRIPTION
## Summary
This PR adds support for injecting a custom database path into `DataProxy_SQLite`, enabling tests to use isolated temporary databases instead of the user's real database file. This eliminates the need for complex backup/restore logic in test setup and teardown.

## Key Changes
- Added a new overloaded constructor to `DataProxy_SQLite` that accepts a `_dbPath` parameter, allowing callers to specify a custom database location
- Updated `tst_dataproxy.cpp` to use the new constructor with a temporary test database path, removing ~50 lines of complex backup/restore logic
- Updated `tst_filemanager.cpp` to use the new constructor with a temporary test database path, simplifying its setup/teardown code
- Removed error checking (`QVERIFY2`) for file operations that are non-critical (leftover file cleanup)

## Implementation Details
- The new constructor follows the same initialization pattern as the existing constructor, but passes the custom `_dbPath` directly to the `DataBase` constructor instead of deriving it from `Utilities::getKLogDBFile()`
- Test cases now use dedicated temporary database files (`testDbPath`) that are cleaned up after each test run
- This approach is safer and cleaner than the previous method of backing up/restoring the real user database during test execution

https://claude.ai/code/session_01FHoi9aNmHLtPQLvPtoJx48