### PR TITLE
Add mode-aware QSO status checking for awards

### DIFF
--- a/src/awards.cpp
+++ b/src/awards.cpp
@@ -737,36 +737,45 @@ QString Awards::status2Message(const QSOStatus &_status)
 {
 
     //enum QSOStatus {unknown, ATNO, needed, worked, confirmed};
+    QString msg;
+
     switch (_status) {
     case ATNO:
        //qDebug() << Q_FUNC_INFO << " - ATNO";
-        return QObject::tr("New One, work it!");
+           msg = tr("New One, work it!");
         break;
     case needed:
        //qDebug() << Q_FUNC_INFO << " - Needed";
-        return QObject::tr("Needed, work it!");
-        //message = QObject::tr("1-Needed, work it!");
+        if (manageModes)
+            msg = tr("Needed (band/mode), work it!");
+        else
+            msg = tr("Needed, work it!");
         break;
     case worked:
        //qDebug() << Q_FUNC_INFO << " - Worked";
-        return QObject::tr("Worked but not confirmed");
+        if (manageModes)
+            msg = tr("Worked (band/mode) but not confirmed");
+        else
+            msg = tr("Worked but not confirmed");
         break;
     case confirmed:
        //qDebug() << Q_FUNC_INFO << " - Confirmed";
         return QObject::tr("Confirmed");
+       if (manageModes)
+           msg = tr("Confirmed (band/mode)");
+       else
+           msg = tr("Confirmed");
         break;
     case unknown:
         //qDebug() << Q_FUNC_INFO << " - Unknown";
-        return QObject::tr("Unknown!");
+        msg = tr("Unknown!");
         break;
     //break;
     default:
-        qDebug() << Q_FUNC_INFO << " - Default: " << _status;
-        QString msg = QString("Not identified: %1").arg(_status);
-        //return QObject::tr("Not identified");
-        return msg;
+        msg = tr("Not identified");
         break;
     }
+    return msg;
 }
 
 

--- a/src/awardswidget.cpp
+++ b/src/awardswidget.cpp
@@ -54,6 +54,7 @@ AwardsWidget::AwardsWidget(DataProxy_SQLite *dp, World *injectedWorld, QWidget *
     yearlyScoreLabelN = new QLabel();
 
     recalculateAwardsButton = new QPushButton;
+    includeModeForNeededCheckBox = new QCheckBox;
     dataProxy = dp;
     world = injectedWorld;
     awards = new Awards(dataProxy, world, Q_FUNC_INFO);
@@ -96,6 +97,9 @@ void AwardsWidget::createUI()
 
     recalculateAwardsButton = new QPushButton(tr("Recalculate"), this);
     recalculateAwardsButton->setToolTip(tr("Click to recalculate the award status."));
+    includeModeForNeededCheckBox->setText(tr("Check band && mode for needed"));
+    includeModeForNeededCheckBox->setChecked(false);
+    includeModeForNeededCheckBox->setToolTip(tr("If checked, KLog considers both band and mode when evaluating if a QSO is needed or confirmed."));
     operatingYearsComboBox->setToolTip(tr("Select the year you want to check."));
 
     QLabel *yearlyQSOsLabelN = new QLabel(tr("QSOs"));
@@ -239,6 +243,7 @@ void AwardsWidget::createUI()
       //qDebug() << "AwardsWidget::createUI-167"  ;
     dxUpRightAwardsTabLayout->addLayout(yearlyDLayout, 5, 1, 1, -1);
       //qDebug() << "AwardsWidget::createUI-168"  ;
+    dxUpRightAwardsTabLayout->addWidget(includeModeForNeededCheckBox, 6, 0);
     dxUpRightAwardsTabLayout->addWidget(recalculateAwardsButton, 6, 1);
 
       //qDebug() << "AwardsWidget::createUI-200"  ;
@@ -252,6 +257,7 @@ void AwardsWidget::createUI()
     connect(operatingYearsComboBox, SIGNAL(currentIndexChanged ( int)), this, SLOT(slotOperatingYearComboBoxChanged() ) ) ;
     connect(recalculateAwardsButton, SIGNAL(clicked()), this, SLOT(slotRecalculateAwardsButtonClicked() ) );
     connect(dataProxy, &DataProxy_SQLite::logChanged, this, &AwardsWidget::slotRefreshYearsComboBox);
+    connect(includeModeForNeededCheckBox, SIGNAL(stateChanged(int)), this, SLOT(slotIncludeModeForNeededChanged(int)));
     emit debugLog (Q_FUNC_INFO, "END", Debug);
       //qDebug() << "AwardsWidget::createUI-END"  ;
 }
@@ -505,4 +511,25 @@ void AwardsWidget::slotRefreshYearsComboBox()
     fillOperatingYears();  // reutiliza la lógica correcta y consistente
     showAwards();          // refresca los LCD (contadores de QSOs, etc.)
     emit debugLog(Q_FUNC_INFO, "End", Devel);
+}
+
+void AwardsWidget::slotIncludeModeForNeededChanged(int state)
+{
+    emit debugLog(Q_FUNC_INFO, "Start", Devel);
+    emit includeModeForNeededChanged(state != 0);
+    emit debugLog(Q_FUNC_INFO, "End", Devel);
+}
+
+void AwardsWidget::setIncludeModeForNeeded(const bool _include)
+{
+    emit debugLog(Q_FUNC_INFO, "Start", Devel);
+    includeModeForNeededCheckBox->blockSignals(true);
+    includeModeForNeededCheckBox->setChecked(_include);
+    includeModeForNeededCheckBox->blockSignals(false);
+    emit debugLog(Q_FUNC_INFO, "End", Devel);
+}
+
+bool AwardsWidget::getIncludeModeForNeeded()
+{
+    return includeModeForNeededCheckBox->isChecked();
 }

--- a/src/awardswidget.h
+++ b/src/awardswidget.h
@@ -50,10 +50,14 @@ public:
     void showAwards();
     void clear();
 
+    void setIncludeModeForNeeded(const bool _include);
+    bool getIncludeModeForNeeded();
+
 private slots:
      void slotRecalculateAwardsButtonClicked();
      void slotOperatingYearComboBoxChanged();
      void slotRefreshYearsComboBox();
+     void slotIncludeModeForNeededChanged(int state);
 
 signals:
     //void actionQSODoubleClicked(const int _qsoid);
@@ -62,6 +66,7 @@ signals:
     //void recalculateAwardsSignal();
     void requireCurrentLogSignal();
     void requireCurrentYearSignal();
+    void includeModeForNeededChanged(bool _include);
 
 private:
     void createUI();
@@ -71,6 +76,7 @@ private:
     void checkIfValidLog();
     void reconfigureDXMarathonUI(const bool _dxM);
 
+    QCheckBox *includeModeForNeededCheckBox;
     QLCDNumber *dxccConfirmedQLCDNumber, *dxccWorkedQLCDNumber,
                 *wazConfirmedQLCDNumber, *wazWorkedQLCDNumber,
                 *localConfirmedQLCDNumber, *localWorkedQLCDNumber,

--- a/src/dxccstatuswidget.cpp
+++ b/src/dxccstatuswidget.cpp
@@ -63,6 +63,8 @@ DXCCStatusWidget::DXCCStatusWidget(Awards *awards, World *injectedWorld, QWidget
     logNumber = -1; // -1 means that ALL the logs will be used (if showAllLogsButton is not checked)
     tempLog = -1;   // -1 means that ALL the logs will be used
     loc = QString();
+    includeModeForNeeded = false;
+    currentMode = -1;
     refreshButton = new QPushButton;
 
     bandNames.clear();
@@ -253,7 +255,7 @@ void DXCCStatusWidget::addEntity(const QList<int> &_ent)
     {
        //qDebug() << Q_FUNC_INFO << ": " << entity.mainprefix << " - i = " << QString::number(i) << "/" << _ent.at(i);
         int bandId = _ent.at(i);
-        int modeId = -1;            // TODO: Add a proposed mode, if possible.        
+        int modeId = includeModeForNeeded ? currentMode : -1;
         QSOStatus qsoStatus = awards->getQSOStatus(_dxcc, bandId, modeId);
         //QSOStatus qsoStatus = awards->getDXCCStatusBand(_dxcc, bandid);
         QString qsoStatusString = awards->status2String(qsoStatus);
@@ -671,6 +673,16 @@ void DXCCStatusWidget::setMyLocator(const QString &_loc)
     {
         loc = l.toUpper();
     }
+}
+
+void DXCCStatusWidget::setIncludeModeForNeeded(const bool _include)
+{
+    includeModeForNeeded = _include;
+}
+
+void DXCCStatusWidget::setCurrentMode(const int _modeId)
+{
+    currentMode = _modeId;
 }
 
 void DXCCStatusWidget::setColors (const QColor &_newOne, const QColor &_needed, const QColor &_worked, const QColor &_confirmed, const QColor &_default)

--- a/src/dxccstatuswidget.h
+++ b/src/dxccstatuswidget.h
@@ -52,6 +52,8 @@ public:
     void setColors (const QColor &_newOne, const QColor &_needed, const QColor &_worked, const QColor &_confirmed, const QColor &_default);
     void setCurrentLog(const int _logN);
     void setMyLocator(const QString &_loc);
+    void setIncludeModeForNeeded(const bool _include);
+    void setCurrentMode(const int _modeId);
     void refresh();
 
 signals:
@@ -103,6 +105,8 @@ private:
     QStringList bandNames;//, validBands;
     int logNumber, tempLog; // log in use in the log / log to be used in the widget
     QString loc; // The locator of the user.
+    bool includeModeForNeeded;
+    int currentMode;
 
     QAction *showDXCCWikipediaAct;
     int currentLog;

--- a/src/dxcluster/dxcluster.cpp
+++ b/src/dxcluster/dxcluster.cpp
@@ -137,6 +137,7 @@ void DXClusterWidget::init()
     saveSpots = false;
     myQrz = QString();
     currentLog = 0;
+    includeModeForNeeded = false;
     server = "dxfun.com";
     port = quint16(8000);
     Utilities util(Q_FUNC_INFO);
@@ -577,6 +578,11 @@ void DXClusterWidget::setColors (const QColor &_newOne, const QColor &_needed, c
     awards->setColors(_newOne,  _needed, _worked,  _confirmed, _default);
 }
 
+void DXClusterWidget::setIncludeModeForNeeded(const bool _include)
+{
+    includeModeForNeeded = _include;
+}
+
 void DXClusterWidget::setDXClusterSpotConfig(bool _showhf, bool _showvhf, bool _showwarc, bool _showworked, bool _showconfirmed, bool _showann, bool _showwwv, bool _showwcy )
 {
    //qDebug() << Q_FUNC_INFO;
@@ -687,12 +693,12 @@ DXSpot DXClusterWidget::readItem(const QString _stringSpot)
             spot.setDXCall(fields.at(4));
             entityStatus.bandId = dataProxy->getBandIdFromFreq(spot.getFrequency().toDouble());
             entityStatus.dxcc = world->getQRZARRLId(spot.getDxCall());
-            entityStatus.status = awards->getQSOStatus(entityStatus.dxcc, entityStatus.bandId, entityStatus.modeId);
+            entityStatus.status = awards->getQSOStatus(entityStatus.dxcc, entityStatus.bandId, includeModeForNeeded ? entityStatus.modeId : -1);
             spot.setQSOStatus(entityStatus.status);
 
 
             QString aux = fields.last();
-            aux.chop(1);            
+            aux.chop(1);
             QTime time = QTime::fromString(aux,"HHmm");
             QDateTime datetime = QDateTime::currentDateTime();
             datetime.setTime(time);
@@ -719,7 +725,7 @@ DXSpot DXClusterWidget::readItem(const QString _stringSpot)
         spot.setDXCall(fields.at(1));
         entityStatus.bandId = dataProxy->getBandIdFromFreq(spot.getFrequency().toDouble());
         entityStatus.dxcc = world->getQRZARRLId(spot.getDxCall());
-        entityStatus.status = awards->getQSOStatus(entityStatus.dxcc, entityStatus.bandId, entityStatus.modeId);
+        entityStatus.status = awards->getQSOStatus(entityStatus.dxcc, entityStatus.bandId, includeModeForNeeded ? entityStatus.modeId : -1);
         spot.setQSOStatus(entityStatus.status);
 
         QString spotter = fields.last();

--- a/src/dxcluster/dxcluster.h
+++ b/src/dxcluster/dxcluster.h
@@ -65,6 +65,7 @@ class DXClusterWidget : public QWidget
     void setSaveSpots (const bool _enable);
     void loadSettings();
     void setDXClusterServer(const QString &clusterToConnect, const int portToConnect);
+    void setIncludeModeForNeeded(const bool _include);
 
     void rightButtonFromLogMenu(const DXSpot &_spot);
 
@@ -137,6 +138,7 @@ private:
 
     QString myQrz;
     int currentLog;
+    bool includeModeForNeeded;
 
     QFile *saveSpotsFile;
     bool saveSpots; // write/save the spots to a file

--- a/src/infowidget.cpp
+++ b/src/infowidget.cpp
@@ -63,6 +63,8 @@ InfoWidget::InfoWidget(Awards *awards, World *injectedWorld, QWidget *parent) :
     distLongLabelN = new QLabel;
 
     imperialSystem=false;
+    includeModeForNeeded = false;
+    currentMode = -1;
     dxLocator.clear();
 
     createUI();
@@ -352,6 +354,16 @@ void InfoWidget::setCurrentLog(const int _log)
     currentLog = _log;
 }
 
+void InfoWidget::setIncludeModeForNeeded(const bool _include)
+{
+    includeModeForNeeded = _include;
+}
+
+void InfoWidget::setCurrentMode(const int _modeId)
+{
+    currentMode = _modeId;
+}
+
 void InfoWidget::setImperialSystem (const  bool _imp)
 {
     imperialSystem = _imp;
@@ -378,7 +390,8 @@ QString InfoWidget::getStyleColorToLabelFromBand(const int _bandId, const int _e
         return "* { background-color: " + awards->getDefaultColor().name(QColor::HexRgb) + "; }";
     }
 
-    const QSOStatus status = awards->getQSOStatus(_entityId, _bandId, -1);     //- -1 just to match bands, no modes
+    const int modeToCheck = includeModeForNeeded ? currentMode : -1;
+    const QSOStatus status = awards->getQSOStatus(_entityId, _bandId, modeToCheck);
 
    //qDebug() << Q_FUNC_INFO << " -            Status: " << status;
    //qDebug() << Q_FUNC_INFO << " - Color from Status: " << awards->getColorFromStatus(status).name(QColor::HexRgb);

--- a/src/infowidget.h
+++ b/src/infowidget.h
@@ -52,6 +52,8 @@ public:
     void setCurrentLog(const int _log);
     void setColors (const QColor &_newOne, const QColor &_needed, const QColor &_worked, const QColor &_confirmed, const QColor &_default);
     void setImperialSystem (const  bool _imp);
+    void setIncludeModeForNeeded(const bool _include);
+    void setCurrentMode(const int _modeId);
     void showInfo(const int _entity);
     void showDistanceAndBearing(const QString &_locLocal, const QString &_loc2);
     void showEntityInfo(const int _enti, int _cq=-1, int _itu=-1);
@@ -80,6 +82,8 @@ private:
 
     int currentLog;
     bool imperialSystem;
+    bool includeModeForNeeded;
+    int currentMode;
     QString dxLocator;
 };
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -674,6 +674,7 @@ void MainWindow::createActionsCommon(){
 
     connect(awardsWidget, SIGNAL(requireCurrentLogSignal()), this, SLOT(slotAwardsWidgetSetLog()) );
     connect(awardsWidget, SIGNAL(requireCurrentYearSignal()), this, SLOT(slotAwardsWidgetSetYear()) );
+    connect(awardsWidget, &AwardsWidget::includeModeForNeededChanged, this, &MainWindow::slotIncludeModeForNeededChanged);
 
     //DXCCWIDGET TAB
     //connect(dxccStatusWidget, SIGNAL(showQso(int)), this, SLOT(slotShowQSOFromDXCCWidget(int) ) );
@@ -1007,7 +1008,7 @@ void MainWindow::slotBandChanged (const QString &_b)
        //qDebug() << "MainWindow:: - calling showStatusOfDXCC-02 " ;
     if (currentEntity>0)
     {
-        _entityStatus.status = awards.getQSOStatus(_entityStatus.dxcc, _entityStatus.bandId, _entityStatus.modeId);
+        _entityStatus.status = awards.getQSOStatus(_entityStatus.dxcc, _entityStatus.bandId, manageMode ? _entityStatus.modeId : -1);
         showStatusOfDXCC(_entityStatus);
     }
     changingBand = false;
@@ -1029,6 +1030,7 @@ void MainWindow::slotModeChanged (const QString &_m)
     currentModeShown = dataProxy->getIdFromModeName(_m);
     currentBand = currentBandShown;
     currentMode = currentModeShown;
+    infoWidget->setCurrentMode(currentModeShown);
 
     EntityStatus _entityStatus;
     _entityStatus.dxcc      = currentEntity;
@@ -1036,7 +1038,7 @@ void MainWindow::slotModeChanged (const QString &_m)
     _entityStatus.modeId    = currentModeShown;
     _entityStatus.logId     = currentLog;
 
-    _entityStatus.status    = awards.getQSOStatus(_entityStatus.dxcc, _entityStatus.bandId, _entityStatus.modeId);
+    _entityStatus.status    = awards.getQSOStatus(_entityStatus.dxcc, _entityStatus.bandId, manageMode ? _entityStatus.modeId : -1);
     showStatusOfDXCC(_entityStatus);
     if (!modify)
     {
@@ -2161,7 +2163,7 @@ void MainWindow::slotQRZTextChanged(QString _qrz)
         infoWidget->showEntityInfo(currentEntity, dx_CQz, dx_ITUz);
         infoWidget->showDistanceAndBearing(myDataTabWidget->getMyLocator(), dxLocator);
 
-        _entityStatus.status = awards.getQSOStatus(_entityStatus.dxcc , _entityStatus.bandId, _entityStatus.modeId);
+        _entityStatus.status = awards.getQSOStatus(_entityStatus.dxcc , _entityStatus.bandId, manageMode ? _entityStatus.modeId : -1);
         //awards.printEntityStatus(Q_FUNC_INFO, _entityStatus);
 
         showStatusOfDXCC(_entityStatus);
@@ -4650,7 +4652,7 @@ void MainWindow::qsoToEdit (const int _qso)
     _entityStatus.logId     = currentLog;
 
    //qDebug() << Q_FUNC_INFO << " - in default - 104"  ;
-    _entityStatus.status    = awards.getQSOStatus(_entityStatus.dxcc, _entityStatus.bandId, _entityStatus.modeId);
+    _entityStatus.status    = awards.getQSOStatus(_entityStatus.dxcc, _entityStatus.bandId, manageMode ? _entityStatus.modeId : -1);
     showStatusOfDXCC(_entityStatus);
 
     readingTheUI = false;
@@ -4753,6 +4755,27 @@ void MainWindow::showDXMarathonNeeded(const int _dxcc, const int _cqz, const int
         slotShowInfoLabel(infoLabel1->text()+ tr(" - Needed for DXMarathon"));
         //infoLabel1->setText(infoLabel1->text()+ tr(" - Needed for DXMarathon"));
     }
+    logEvent(Q_FUNC_INFO, "END", Debug);
+}
+
+void MainWindow::slotIncludeModeForNeededChanged(const bool _include)
+{
+    logEvent(Q_FUNC_INFO, "Start", Devel);
+    manageMode = _include;
+    awards.setManageModes(manageMode);
+    infoWidget->setIncludeModeForNeeded(manageMode);
+    infoWidget->setCurrentMode(currentModeShown);
+    searchWidget->setIncludeModeForNeeded(manageMode);
+    dxClusterWidget->setIncludeModeForNeeded(manageMode);
+    dxccStatusWidget->setIncludeModeForNeeded(manageMode);
+    dxccStatusWidget->setCurrentMode(currentModeShown);
+
+    // Save the setting immediately so the Misc tab shows updated state on next open
+    QSettings settings(util->getCfgFile(), QSettings::IniFormat);
+    settings.beginGroup("Misc");
+    settings.setValue("IncludeModeForNeeded", QVariant(manageMode));
+    settings.endGroup();
+
     logEvent(Q_FUNC_INFO, "END", Debug);
 }
 
@@ -6398,6 +6421,8 @@ bool MainWindow::loadSettings()
     sendQSLWhenRec = (settings.value ("SendQSLWhenRec", true).toBool ());
     manageDxMarathon = (settings.value ("ManageDXMarathon", false).toBool ());
     awardsWidget->setManageDXMarathon (manageDxMarathon);
+    manageMode = (settings.value ("IncludeModeForNeeded", false).toBool ());
+    awardsWidget->setIncludeModeForNeeded (manageMode);
     searchWidget->setShowCallInSearch(settings.value ("ShowCallsignInSearch", true).toBool ());
     checkNewVersions = settings.value ("CheckNewVersions", true).toBool ();
     reportInfo = false;
@@ -6418,6 +6443,15 @@ bool MainWindow::loadSettings()
     //filemanager->setCallValidation(settings.value ("CheckValidCalls", true).toBool ());
     //adifLoTWExportWidget->setCallValidation(settings.value ("CheckValidCalls", true).toBool ());
     settings.endGroup ();
+
+    // Propagate IncludeModeForNeeded to all subwidgets
+    awards.setManageModes(manageMode);
+    infoWidget->setIncludeModeForNeeded(manageMode);
+    infoWidget->setCurrentMode(currentModeShown);
+    searchWidget->setIncludeModeForNeeded(manageMode);
+    dxClusterWidget->setIncludeModeForNeeded(manageMode);
+    dxccStatusWidget->setIncludeModeForNeeded(manageMode);
+    dxccStatusWidget->setCurrentMode(currentModeShown);
 
       //qDebug() << Q_FUNC_INFO << " - 90 - elog";
     settings.beginGroup ("ClubLog");

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4769,6 +4769,12 @@ void MainWindow::slotIncludeModeForNeededChanged(const bool _include)
     dxClusterWidget->setIncludeModeForNeeded(manageMode);
     dxccStatusWidget->setIncludeModeForNeeded(manageMode);
     dxccStatusWidget->setCurrentMode(currentModeShown);
+    dxccStatusWidget->refresh();
+
+
+    awardsWidget->fillOperatingYears();
+    awardsWidget->showAwards();
+
 
     // Save the setting immediately so the Misc tab shows updated state on next open
     QSettings settings(util->getCfgFile(), QSettings::IniFormat);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -203,6 +203,7 @@ private slots:
     void slotElogQRZCOMDisable(const bool _b);
 
     void slotShowAwards();
+    void slotIncludeModeForNeededChanged(const bool _include);
     void slotUpdateStatusBar(const QString &statusm);
     void setMainWindowTitle();
     void slotSetup(const int _page=0);

--- a/src/searchmodel.cpp
+++ b/src/searchmodel.cpp
@@ -33,6 +33,7 @@ SearchModel::SearchModel(Awards *awards, QObject *parent):
     //qDebug() << "SearchModel::SearchModel " ;
     dataProxy = awards->dataProxy;
     stationCallsignInHeader = true;
+    includeModeForNeeded = false;
     setTable("log");
     setEditStrategy(QSqlTableModel::OnFieldChange);
     dxcc = -1;
@@ -113,6 +114,11 @@ void SearchModel::setStationCallsignInHeader(const bool _s)
     stationCallsignInHeader = _s;
 }
 
+void SearchModel::setIncludeModeForNeeded(const bool _include)
+{
+    includeModeForNeeded = _include;
+}
+
 void SearchModel::setFilterString(const QString &_st)
  {
     //qDebug() << "SearchModel::setFilterString: " << _st;
@@ -149,7 +155,7 @@ QVariant SearchModel::data( const QModelIndex &index, int role ) const
             _entityStatus.bandId    = dataProxy->getIdFromBandName(index.siblingAtColumn(bandid).data().toString());
             _entityStatus.modeId    = dataProxy->getIdFromModeName(index.siblingAtColumn(modeid).data().toString());
             _entityStatus.logId     = index.siblingAtColumn(logn).data().toInt();
-            _entityStatus.status    = award->getQSOStatus(_entityStatus.dxcc, _entityStatus.bandId, _entityStatus.modeId);
+            _entityStatus.status    = award->getQSOStatus(_entityStatus.dxcc, _entityStatus.bandId, includeModeForNeeded ? _entityStatus.modeId : -1);
             //award->printEntityStatus(Q_FUNC_INFO, _entityStatus);
             return QVariant( award->getEntityStatusColor(_entityStatus) );
 

--- a/src/searchmodel.h
+++ b/src/searchmodel.h
@@ -50,6 +50,7 @@ public:
     void setBandIdColumn(const int _i);
     void setModeIdColumn(const int _i);
     void setLogNColumn(const int _i);
+    void setIncludeModeForNeeded(const bool _include);
 
 private:
     //void setColumnsToDX();
@@ -58,6 +59,7 @@ private:
     Awards *award;
     DataProxy_SQLite *dataProxy;
     bool stationCallsignInHeader;
+    bool includeModeForNeeded;
     int dxcc, bandid, modeid, logn;
 signals:
     void queryError(QString functionFailed, QString errorCodeS, QString nativeError, QString failedQuery); // To alert about any failed query execution

--- a/src/searchwidget.cpp
+++ b/src/searchwidget.cpp
@@ -103,6 +103,11 @@ void SearchWidget::setShowCallInSearch(const bool _sh)
     searchWindow->setStationCallsignInHeader(stationCallSignShownInSearch);
 }
 
+void SearchWidget::setIncludeModeForNeeded(const bool _include)
+{
+    searchWindow->setIncludeModeForNeeded(_include);
+}
+
 
 
 void SearchWidget::setVersion (const QString &_version)

--- a/src/searchwidget.h
+++ b/src/searchwidget.h
@@ -47,6 +47,7 @@ public:
     //void setColors (const QString &_newOne, const QString &_needed, const QString &_worked, const QString &_confirmed, const QString &_default);
     void setVersion (const QString &_version); // Defines the KLog version to be written in the exported logs
     void setShowCallInSearch(const bool _sh);
+    void setIncludeModeForNeeded(const bool _include);
     void clear();
     void showQSO(const int _q);
     void showQSOs(QList<int> qsoIdList);

--- a/src/searchwindow.cpp
+++ b/src/searchwindow.cpp
@@ -131,6 +131,11 @@ void SearchWindow::setStationCallsignInHeader(const bool _h)
     setColumnsToDX();
 }
 
+void SearchWindow::setIncludeModeForNeeded(const bool _include)
+{
+    searchModel->setIncludeModeForNeeded(_include);
+}
+
 void SearchWindow::createlogPanel(const int _currentLog)
 {
       //qDebug() << "SearchWindow::createlogPanel: " << QString::number(_currentLog);

--- a/src/searchwindow.h
+++ b/src/searchwindow.h
@@ -57,6 +57,7 @@ public:
     void selectAll();
     void clearSelection();
     void setStationCallsignInHeader(const bool _h);
+    void setIncludeModeForNeeded(const bool _include);
 
 
     void qslSentViaBureau(const int _qsoId);    //Maybe this could be defined as private and call it with an action, if needed.

--- a/src/setuppages/setuppagemisc.cpp
+++ b/src/setuppages/setuppagemisc.cpp
@@ -48,6 +48,7 @@ SetupPageMisc::SetupPageMisc(QWidget *parent) : QWidget(parent){
     checkNewVersionCheckBox = new QCheckBox(tr("&Check for new versions automatically"), this);
     //provideCallCheckBox = new QCheckBox(tr("&Provide Info for statistics"), this);
     useDxMarathonCheckBox = new QCheckBox(tr("Manage DX-Marathon"), this);
+    includeModeForNeededCheckBox = new QCheckBox(tr("Check band && mode for needed status"), this);
 
     //logSortCheckBox = new QCheckBox(tr("Sort log based in date && time"));
     sendEQSLByDefaultSearchCheckBox = new QCheckBox(tr("Mark sent eQSL && LoTW in new QSO as queued"));
@@ -128,6 +129,8 @@ void SetupPageMisc::createUI()
     checkCallsCheckBox->setEnabled (true);
     checkCallsCheckBox->setChecked (true);
     checkCallsCheckBox->setToolTip (tr("If you disable this checkbox KLog will not check callsigns to identify wrong callsigns."));
+    includeModeForNeededCheckBox->setChecked(false);
+    includeModeForNeededCheckBox->setToolTip(tr("If checked, KLog will consider both band and mode when evaluating if a QSO is needed or confirmed. If unchecked, only the band is taken into account."));
     sendQSLWhenRecCheckBox->setToolTip(tr("QSOs will be marked as pending to send a QSL if you receive the DX QSL and have not sent yours."));
     showStationCallWhenSearchCheckBox->setToolTip(tr("The search box will also show the callsign on the air to do the QSO."));
     //keepMyDataCheckBox->setToolTip(tr("All the data from the My Data tab will be used or data from the previous QSO will be maintained."));
@@ -199,6 +202,7 @@ void SetupPageMisc::createUI()
     mainLayout->addWidget(showStationCallWhenSearchCheckBox, 8, 0, 1, 1);
     mainLayout->addWidget(deleteAlwaysAdiFileCheckBox, 8, 1, 1, 1);
     mainLayout->addWidget (checkCallsCheckBox, 9, 0, 1, 1);
+    mainLayout->addWidget (includeModeForNeededCheckBox, 9, 1, 1, 1);
 
     setLayout(mainLayout);
 }
@@ -598,6 +602,16 @@ void SetupPageMisc::setCheckCalls(const bool &_t)
     checkCallsCheckBox->setChecked (_t);
 }
 
+bool SetupPageMisc::getIncludeModeForNeeded()
+{
+    return includeModeForNeededCheckBox->isChecked();
+}
+
+void SetupPageMisc::setIncludeModeForNeeded(const bool _t)
+{
+    includeModeForNeededCheckBox->setChecked(_t);
+}
+
 void SetupPageMisc::saveSettings()
 {
     //qDebug() << Q_FUNC_INFO ;
@@ -620,6 +634,7 @@ void SetupPageMisc::saveSettings()
     settings.setValue ("SendEQSLByDefault", QVariant((sendEQSLByDefaultSearchCheckBox->isChecked())));
     settings.setValue ("DeleteAlwaysAdiFile", QVariant((deleteAlwaysAdiFileCheckBox->isChecked())));
     settings.setValue ("CheckValidCalls", QVariant((checkCallsCheckBox->isChecked())));
+    settings.setValue ("IncludeModeForNeeded", QVariant((includeModeForNeededCheckBox->isChecked())));
     if (dupeTimeLineEdit->text().toInt()>1)
         settings.setValue ("DuplicatedQSOSlot", dupeTimeLineEdit->text());
     else
@@ -652,6 +667,7 @@ void SetupPageMisc::loadSettings(const QString &_callingFunction)
     sendEQSLByDefaultSearchCheckBox->setChecked (settings.value("SendEQSLByDefault", true).toBool ());
     deleteAlwaysAdiFileCheckBox->setChecked (settings.value("DeleteAlwaysAdiFile").toBool ());
     checkCallsCheckBox->setChecked (settings.value("CheckValidCalls").toBool ());
+    includeModeForNeededCheckBox->setChecked (settings.value("IncludeModeForNeeded", false).toBool ());
     //provideCallCheckBox->setChecked (settings.value("ProvideInfo").toBool ());
 
     setDefaultFileName(settings.value("DefaultADIFFile").toString ());

--- a/src/setuppages/setuppagemisc.h
+++ b/src/setuppages/setuppagemisc.h
@@ -78,6 +78,8 @@ public:
     QString getDeleteAlwaysAdiFile();
     bool getCheckCalls();
     void setCheckCalls(const bool &_t);
+    bool getIncludeModeForNeeded();
+    void setIncludeModeForNeeded(const bool _t);
 
     //void setDupeTime(const int _t);
     //int getDupeTime();
@@ -106,7 +108,7 @@ private:
 
     QCheckBox *realTimeCheckbox, *showSecondsCheckBox, *UTCCheckbox, *alwaysADIFCheckBox, *useDefaultName, *completeWithPreviousCheckBox;
     QCheckBox *imperialCheckBox, *sendQSLWhenRecCheckBox, *showStationCallWhenSearchCheckBox;
-    QCheckBox *checkNewVersionCheckBox, *provideCallCheckBox, *useDxMarathonCheckBox, *checkCallsCheckBox;
+    QCheckBox *checkNewVersionCheckBox, *provideCallCheckBox, *useDxMarathonCheckBox, *checkCallsCheckBox, *includeModeForNeededCheckBox;
     // qCheckBox *logSortCheckBox;
     QCheckBox *sendEQSLByDefaultSearchCheckBox, *deleteAlwaysAdiFileCheckBox;
     QString defaultFileName;


### PR DESCRIPTION
## Summary
This PR introduces a new feature that allows users to optionally consider both band AND mode when evaluating whether a QSO is needed or confirmed for awards purposes. Previously, only the band was considered. This is controlled by a new "Check band && mode for needed status" checkbox that can be toggled in the Misc settings tab and the Awards widget.

## Key Changes

- **New Setting**: Added `IncludeModeForNeeded` configuration option that persists across sessions
- **Awards Widget**: Added checkbox to toggle mode-aware QSO status checking with immediate setting persistence
- **Setup Page**: Added checkbox in Misc tab to control the mode-aware behavior
- **QSO Status Queries**: Updated all calls to `awards.getQSOStatus()` to conditionally pass the mode ID based on the `manageMode` flag:
  - `slotBandChanged()`, `slotModeChanged()`, `slotQRZTextChanged()`, `qsoToEdit()`
  - DXCluster widget spot processing
  - Search model data display
  - Info widget and DXCC status widget color calculations
- **Widget Propagation**: When the setting changes, it's propagated to all relevant widgets:
  - InfoWidget, SearchWidget, DXClusterWidget, DXCCStatusWidget
  - Awards system via `awards.setManageModes()`
- **Mode Tracking**: Added `currentMode` tracking to InfoWidget and DXCCStatusWidget to support mode-aware display updates
- **Settings Persistence**: Settings are saved immediately when the checkbox is toggled and loaded on application startup

## Implementation Details

- The feature uses a conditional ternary operator pattern: `manageMode ? _entityStatus.modeId : -1` where `-1` indicates "any mode"
- A new slot `slotIncludeModeForNeededChanged()` in MainWindow handles propagating the setting change to all dependent components
- The checkbox state is blocked during programmatic updates to prevent unwanted signal cascades
- All settings are properly loaded during `loadSettings()` and saved in `SetupPageMisc::saveSettings()`

https://claude.ai/code/session_01SjCafzconZPdCCqnbPhpmc