### PR TITLE
Update awards and DXCC widgets when log selection changes

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3309,6 +3309,11 @@ void MainWindow::slotSetupDialogFinished (const int _s)
             currentLog = newSelectedLog;
             logWindow->createlogPanel(currentLog);
             dataProxy->loadDuplicateCache(currentLog);
+            awardsWidget->setLog(currentLog);
+            awardsWidget->fillOperatingYears();
+            awardsWidget->showAwards();
+            dxccStatusWidget->setCurrentLog(currentLog);
+            dxccStatusWidget->refresh();
         }
         else if (columnsModified)
         {


### PR DESCRIPTION
## Summary
When a log is selected in the setup dialog, the awards and DXCC status widgets are now properly updated to reflect the newly selected log.

## Key Changes
- Added calls to refresh the awards widget when a log is selected:
  - `awardsWidget->setLog(currentLog)` - Sets the active log
  - `awardsWidget->fillOperatingYears()` - Populates operating year data
  - `awardsWidget->showAwards()` - Displays awards for the selected log
- Added calls to refresh the DXCC status widget:
  - `dxccStatusWidget->setCurrentLog(currentLog)` - Sets the active log
  - `dxccStatusWidget->refresh()` - Updates the display

## Implementation Details
These widget updates are now performed in the `slotSetupDialogFinished()` method immediately after the log is changed and the duplicate cache is loaded, ensuring all UI components stay synchronized with the currently selected log.

https://claude.ai/code/session_01Djqo3GSUrEw93GZd3zJ22U