### PR TITLE
fix: remove redundant model->select() on double-click in logview and searchwindow

### DIFF
--- a/src/logwindow.cpp
+++ b/src/logwindow.cpp
@@ -411,7 +411,10 @@ void LogWindow::slotDoubleClickLog(const QModelIndex & index)
 
     //TODO: To be added to the logWindow and create an action that emist the QSO id to be edited
 
-    logModel->select();
+    // NOTE: logModel->select() was removed here. It triggered a heavy LEFT JOIN query
+    // (log ⟶ band ⟶ mode ⟶ entity) over all QSOs in the log synchronously on the UI thread
+    // right when the user opened the edit view, causing a noticeable delay. The log model
+    // is already refreshed after the QSO is saved via logWindow->refresh() in MainWindow.
     //qDebug() << Q_FUNC_INFO << " - END";
 }
 

--- a/src/searchwindow.cpp
+++ b/src/searchwindow.cpp
@@ -352,7 +352,9 @@ void SearchWindow::slotDoubleClickLog(const QModelIndex & index)
 
     //TODO: To be added to the SearchWindow and create an action that emist the QSO id to be edited
 
-    searchModel->select();
+    // NOTE: searchModel->select() was removed here for the same reason as in LogWindow:
+    // there is no need to reload the model when opening the edit view; the refresh
+    // already happens after the QSO is saved.
 }
 
 bool SearchWindow::isQSLReceived(const int _qsoId)


### PR DESCRIPTION
LogWindow::slotDoubleClickLog called logModel->select() synchronously right
after emitting actionQSODoubleClicked, blocking the UI thread with a heavy
LEFT JOIN query (log ⟶ band ⟶ mode ⟶ entity) over all QSOs in the log.
This caused a noticeable delay before the edit form could respond.

SearchWindow had the same redundant select() call, though less perceptible
because its model uses INNER JOIN and a restrictive search filter (fewer rows).

In both cases the model is already refreshed after the QSO is saved via
logWindow->refresh() / searchWidget->refresh() in MainWindow, so these
select() calls on open-edit were completely unnecessary.

https://claude.ai/code/session_01FRi5rpKyPDqHp8CYcFQXNg