### PR TITLE
fix(windows): guard unistd.h include with #ifndef _WIN32

### DIFF
--- a/src/hamlibclass.h
+++ b/src/hamlibclass.h
@@ -38,7 +38,9 @@
 #include <QtSerialPort/QSerialPort>
 #include <hamlib/rig.h>
 #include <stdio.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <stdlib.h>
 #include <QSettings>
 #include "klogdefinitions.h"


### PR DESCRIPTION
unistd.h is a POSIX-only header not available in MSVC. The file is included in hamlibclass.h but none of its symbols are used on Windows.