### PR TITLE
Persist log table column widths across sessions

### DIFF
--- a/src/logwindow.cpp
+++ b/src/logwindow.cpp
@@ -41,6 +41,7 @@ LogWindow::LogWindow(Awards *awards, QWidget *parent)
     columns.clear();
 
     currentLog = -1;
+    m_blockWidthSave = false;
 
     //awards = new Awards(dataProxy, Q_FUNC_INFO);
 
@@ -171,6 +172,7 @@ void LogWindow::createlogPanel(const int _currentLog)
     // calcular el ancho, lo que con logbooks grandes tarda varios segundos.
     // En su lugar asignamos un ancho fijo razonable por defecto y dejamos
     // que el usuario pueda ajustarlo manualmente arrastrando las columnas.
+    m_blockWidthSave = true;
     logView->horizontalHeader()->setDefaultSectionSize(110);
     logView->horizontalHeader()->setMinimumSectionSize(60);
 
@@ -178,6 +180,8 @@ void LogWindow::createlogPanel(const int _currentLog)
     logView->sortByColumn(1, Qt::DescendingOrder);
 
     retoreColumsOrder();
+    restoreColumnWidths();
+    m_blockWidthSave = false;
     //qDebug() << Q_FUNC_INFO << " - END";
 }
 
@@ -290,6 +294,7 @@ void LogWindow::createActionsCommon()
     connect(logView, SIGNAL(customContextMenuRequested( const QPoint& ) ), this, SLOT(slotRighButtonFromLog( const QPoint& ) ) );
     connect(logView, SIGNAL(doubleClicked ( const QModelIndex& ) ), this, SLOT(slotDoubleClickLog( const QModelIndex& ) ) );
     connect(logView->horizontalHeader(), &QHeaderView::sectionMoved, this, &LogWindow::slotOnSectionMoved);
+    connect(logView->horizontalHeader(), &QHeaderView::sectionResized, this, &LogWindow::slotOnSectionResized);
 
     //qDebug() << Q_FUNC_INFO << " - END";
 }
@@ -849,6 +854,49 @@ void LogWindow::saveColumnOrder()
     settings.beginGroup("LogWindow");
     settings.setValue("ColumnOrder", QVariant::fromValue(columnOrder));
     settings.endGroup();
+}
+
+void LogWindow::slotOnSectionResized(int logicalIndex, int oldSize, int newSize)
+{
+    Q_UNUSED(logicalIndex);
+    Q_UNUSED(oldSize);
+    Q_UNUSED(newSize);
+
+    if (m_blockWidthSave)
+        return;
+
+    saveColumnWidths();
+}
+
+void LogWindow::saveColumnWidths()
+{
+    QHeaderView *header = logView->horizontalHeader();
+    QStringList widths;
+    for (int i = 0; i < header->count(); ++i) {
+        widths.append(QString::number(header->sectionSize(i)));
+    }
+    QSettings settings(util->getCfgFile(), QSettings::IniFormat);
+    settings.beginGroup("LogWindow");
+    settings.setValue("ColumnWidths", widths);
+    settings.endGroup();
+}
+
+void LogWindow::restoreColumnWidths()
+{
+    QSettings settings(util->getCfgFile(), QSettings::IniFormat);
+    settings.beginGroup("LogWindow");
+    QStringList widths = settings.value("ColumnWidths").toStringList();
+    settings.endGroup();
+
+    QHeaderView *header = logView->horizontalHeader();
+    if (widths.size() != header->count())
+        return;
+
+    for (int i = 0; i < widths.size(); ++i) {
+        int w = widths[i].toInt();
+        if (w > 0)
+            header->resizeSection(i, w);
+    }
 }
 
 QStringList LogWindow::getOrderedVisibleHeaders() const

--- a/src/logwindow.cpp
+++ b/src/logwindow.cpp
@@ -153,6 +153,7 @@ void LogWindow::setDefaultData()
 void LogWindow::createlogPanel(const int _currentLog)
 {
     //qDebug() << Q_FUNC_INFO << " - Start : " << QString::number(_currentLog);
+    m_blockWidthSave = true;
     currentLog = _currentLog;
     if (!logModel->createlogModel(currentLog))
     {
@@ -172,7 +173,6 @@ void LogWindow::createlogPanel(const int _currentLog)
     // calcular el ancho, lo que con logbooks grandes tarda varios segundos.
     // En su lugar asignamos un ancho fijo razonable por defecto y dejamos
     // que el usuario pueda ajustarlo manualmente arrastrando las columnas.
-    m_blockWidthSave = true;
     logView->horizontalHeader()->setDefaultSectionSize(110);
     logView->horizontalHeader()->setMinimumSectionSize(60);
 

--- a/src/logwindow.h
+++ b/src/logwindow.h
@@ -104,13 +104,16 @@ private slots:
     void slotMultipleQSLRecViaDirectFromLog();
     void slotQSOsQRZUploadFromLog();
     void slotOnSectionMoved(int logicalIndex, int oldVisualIndex, int newVisualIndex);
+    void slotOnSectionResized(int logicalIndex, int oldSize, int newSize);
 
-private:    
+private:
     void createUI();
     void createActionsCommon();
     void createActions();
     void retoreColumsOrder();
     void saveColumnOrder();
+    void saveColumnWidths();
+    void restoreColumnWidths();
     void deleteQSO(const int _qsoID);
     void rightButtonFromLogMenu(const int trow);
     void rightButtonMultipleFromLogMenu();
@@ -157,6 +160,7 @@ private:
     // qAction *moveToAnotherLog; // MOves the selected QSOs to another log.
 
     int currentLog;
+    bool m_blockWidthSave;
 
     Utilities *util;
     QStringList columns;


### PR DESCRIPTION
## Summary
Add functionality to save and restore column widths in the log table view, allowing users' manual column adjustments to persist between application sessions.

## Key Changes
- Added `m_blockWidthSave` flag to prevent saving column widths during initial panel creation
- Implemented `saveColumnWidths()` method to persist column widths to QSettings
- Implemented `restoreColumnWidths()` method to restore saved column widths on panel creation
- Added `slotOnSectionResized()` slot to detect and save column width changes
- Connected `QHeaderView::sectionResized` signal to trigger width persistence
- Modified `createlogPanel()` to restore column widths after setting defaults and to block saves during initialization

## Implementation Details
- Column widths are stored as a comma-separated list of integers in QSettings under "LogWindow/ColumnWidths"
- The `m_blockWidthSave` flag prevents redundant saves during the initial panel setup when default widths are applied
- Width restoration includes validation to ensure the saved widths match the current column count before applying
- Only positive width values are applied during restoration to avoid invalid dimensions

https://claude.ai/code/session_01B8tnRcbTdSS9LNJZdyZpY7