### PR TITLE
fix: resolve free(): invalid pointer crash on first Linux run

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -270,6 +270,7 @@ int main(int argc, char *argv[])
         StartWizard *wizard = new StartWizard(klogDir, version);
         wizard->setModal(true);
         wizard->exec();
+        delete wizard;
     }
     else
     {   // KLog configuration file exists, let's look for the DB
@@ -294,7 +295,7 @@ int main(int argc, char *argv[])
            //qDebug() << Q_FUNC_INFO << " - DB Updated";
         }
        //qDebug() << Q_FUNC_INFO << " - 98" << (QTime::currentTime()).toString("HH:mm:ss");
-        db->~DataBase();
+        delete db;
       //qDebug() << Q_FUNC_INFO << " 069: " << timer.elapsed() << "ms"; timer.restart();
     }
    //qDebug() << Q_FUNC_INFO << " 070: " << timer.elapsed() << "ms"; timer.restart();

--- a/src/setupdialog.cpp
+++ b/src/setupdialog.cpp
@@ -151,19 +151,10 @@ void SetupDialog::init(const QString &_softwareVersion, const int _page, const b
 SetupDialog::~SetupDialog()
 {
      //qDebug() << Q_FUNC_INFO ;
+    // Page widgets (userDataPage, bandModePage, etc.) are owned by tabWidget via addTab()
+    // and will be deleted automatically by Qt's parent-child mechanism. Explicit deletion
+    // here would cause a double-free crash ("free(): invalid pointer") on Linux.
     delete(locator);
-    delete(userDataPage);
-    delete(bandModePage);
-    delete(dxClusterPage);
-    delete(miscPage);
-    delete(worldEditorPage);
-    delete(logsPage);
-    delete(eLogPage);
-    delete(colorsPage);
-    delete(UDPPage);
-    delete(satsPage);
-    delete(hamlibPage);
-    delete(logViewPage);
     delete(util);
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `SetupDialog::~SetupDialog()` explicitly deleted all tab page widgets (`userDataPage`, `bandModePage`, etc.) that Qt had already re-parented to `tabWidget` via `addTab()`. Qt's parent-child cleanup then tried to delete them a second time → `free(): invalid pointer` crash on Linux when closing the initial settings dialog.
- Fixed `main.cpp`: replaced `db->~DataBase()` (explicitly calling destructor on a heap-allocated object is UB) with correct `delete db`.
- Fixed `main.cpp`: added missing `delete wizard` after `StartWizard::exec()` to avoid a memory leak.

## Test plan

- [ ] Run KLog for the first time on Linux (no `~/.klogrc.cfg` present)
- [ ] Complete the start wizard
- [ ] Open and close the Settings dialog — verify no crash occurs
- [ ] Run KLog again (existing config) — verify normal startup still works

https://claude.ai/code/session_018qaRZSzvPQfNpPumLrX6wh