### PR TITLE
Fix memory management: remove manual deletes of Qt parent objects

### DIFF
--- a/src/infowidget.cpp
+++ b/src/infowidget.cpp
@@ -74,9 +74,7 @@ InfoWidget::InfoWidget(Awards *awards, World *injectedWorld, QWidget *parent) :
 
 InfoWidget::~InfoWidget()
 {
-    delete(awards);
     delete(locator);
-    //delete(world);
 }
 
 void InfoWidget::createUI()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -201,7 +201,7 @@ MainWindow::~MainWindow()
     //delete(elogClublog);
     delete(downloadcty);
     //delete(world);
-    delete(mapWindow);
+    //delete(mapWindow); // Qt parent-child: owned by this, auto-deleted
     //delete(locator);
     //delete(qso);
     delete(backupQSO);


### PR DESCRIPTION
This PR fixes memory management issues by removing manual `delete` calls for Qt objects that are automatically deleted by their parent widgets.

## Summary
Qt's parent-child ownership model automatically handles deletion of child widgets when their parent is destroyed. Manual deletion of these objects can cause double-deletion errors and undefined behavior.

## Key Changes
- **InfoWidget**: Removed manual `delete(awards)` call since awards is owned by InfoWidget
- **MainWindow**: Commented out `delete(mapWindow)` with clarification that it's auto-deleted by parent-child relationship

## Implementation Details
- These objects are created with `this` as the parent (implicit or explicit), making them children of their respective parent widgets
- Qt's object tree automatically deletes children when the parent is destroyed
- Manual deletion is unnecessary and potentially dangerous in this context

https://claude.ai/code/session_01Bf6LCz8ed33k2VwJkBGvLz