### PR TITLE
Fix hamlib rigctld looping between VFOs on every poll cycle (#947)

### DIFF
--- a/src/hamlibclass.cpp
+++ b/src/hamlibclass.cpp
@@ -227,8 +227,11 @@ bool HamLibClass::readFreq()
            //qDebug() << Q_FUNC_INFO << " error on readFreq - END";
            return errorManage(Q_FUNC_INFO, retcode);
     }
-        // In memory mode there is no independent SUB VFO: RX = TX
-    if (currentVfo == RIG_VFO_MEM)
+        // Only query the SUB VFO when split is active; otherwise RX = TX.
+        // Querying RIG_VFO_SUB on many rigs (especially via rigctld) causes
+        // the radio to physically switch VFOs back and forth every poll cycle,
+        // which is the "looping between VFOs" bug reported in issue #947.
+    if (currentVfo == RIG_VFO_MEM || !radioStatus.split)
     {
         radioStatus.freq_VFO_RX = radioStatus.freq_VFO_TX;
         return true;
@@ -266,7 +269,7 @@ bool HamLibClass::readMode()
         //qDebug() << Q_FUNC_INFO << " error on readFreq - END";
         return errorManage(Q_FUNC_INFO, retcode);
     }
-    if (currentVfo == RIG_VFO_MEM)
+    if (currentVfo == RIG_VFO_MEM || !radioStatus.split)
     {
         radioStatus.mode_VFO_RX = radioStatus.mode_VFO_TX;
         return true;
@@ -341,9 +344,9 @@ bool HamLibClass::readRadioInternal()
 
     RadioStatus statusOld = radioStatus;
     if(!readVFO())   return false;
+    if (!readSplit()) return false;
     if(!readFreq())   return false;
     if (!readMode())  return false;
-    if (!readSplit()) return false;
 
     errorCount = 0;
     if (radioStatusChanged(statusOld, radioStatus))


### PR DESCRIPTION
The readFreq() and readMode() functions were unconditionally querying
RIG_VFO_SUB every 300ms poll cycle. For many rigs via rigctld, this
causes a physical VFO switch on the radio to read the sub VFO value,
then switch back — creating visible "looping between VFOs" behavior.

Fix: read split state first (reorder readRadioInternal), then only
query RIG_VFO_SUB when split mode is actually active. When split is
off, RX freq/mode equals TX (same VFO, no SUB query needed).

https://claude.ai/code/session_01QWAXhodL5MPkAMdbaJGtC3