### PR TITLE
Fix QThreadStorage warnings on exit by properly managing QNetworkAccessManager

### DIFF
--- a/src/downloadcty.cpp
+++ b/src/downloadcty.cpp
@@ -41,7 +41,7 @@ DownLoadCTY::DownLoadCTY(const QString &_klogDir, const QString &_klogVersion) :
     klogDir = _klogDir;
     result = -1;  // Error unknown
 
-    manager = new QNetworkAccessManager;
+    manager = new QNetworkAccessManager(this);
     request = new QNetworkRequest;
     //request->setUrl(QUrl("https://www.country-files.com/cty/cty.csv"));
     request->setUrl(QUrl("https://www.country-files.com/bigcty/cty.csv"));
@@ -63,7 +63,7 @@ DownLoadCTY::~DownLoadCTY()
 {
     //delete(util);
     delete(request);
-    delete(manager);
+    manager->deleteLater();
     delete(url);
 
    //qDebug() << "DownLoadCTY::~DownLoadCTY" ;

--- a/src/elog/elogclublog.cpp
+++ b/src/elog/elogclublog.cpp
@@ -55,7 +55,7 @@ eLogClubLog::eLogClubLog()
 eLogClubLog::~eLogClubLog()
 {
     //delete(util);
-    delete(manager);
+    manager->deleteLater();
           //qDebug()<< "eLogClubLog::~eLogClubLog" ;
 }
 

--- a/src/elog/elogqrzlog.cpp
+++ b/src/elog/elogqrzlog.cpp
@@ -68,6 +68,8 @@ eLogQrzLog::eLogQrzLog(DataProxy_SQLite *dp, const QString &_parentFunction, con
 eLogQrzLog::~eLogQrzLog()
 {
     delete(util);
+    manager->deleteLater();
+    managerLog->deleteLater();
     showDebugLog (Q_FUNC_INFO, "END");
 }
 

--- a/src/elog/lotwutilities.cpp
+++ b/src/elog/lotwutilities.cpp
@@ -72,7 +72,7 @@ LoTWUtilities::~LoTWUtilities()
     delete(file);
     delete(pDialog);
     delete(calendar);
-    delete(manager);
+    manager->deleteLater();
       //qDebug() << Q_FUNC_INFO << " - END" ;
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -34,6 +34,7 @@
 #include "updatesettings.h"
 //#include "database.h"
 #include "mainwindow.h"
+#include <QCoreApplication>
 #include <QElapsedTimer>
 
 
@@ -200,6 +201,10 @@ MainWindow::~MainWindow()
     delete(elogQRZcom);
     //delete(elogClublog);
     delete(downloadcty);
+    delete(softUpdate);
+    // Process pending deleteLater() calls from network managers
+    // to avoid QThreadStorage warnings on exit
+    QCoreApplication::processEvents();
     //delete(world);
     //delete(mapWindow); // Qt parent-child: owned by this, auto-deleted
     //delete(locator);
@@ -210,7 +215,6 @@ MainWindow::~MainWindow()
     //delete(dateTime);
     //delete(dateTimeTemp);
     //delete(awards);
-    delete(softUpdate);
     delete(filemanager);
     //delete(fileAwardManager);
     delete(util);


### PR DESCRIPTION
## Summary
This PR fixes QThreadStorage warnings that occur on application exit by properly managing the lifecycle of QNetworkAccessManager instances. The changes ensure that network managers are cleaned up correctly using `deleteLater()` instead of immediate deletion, and that pending events are processed before the application terminates.

## Key Changes
- **MainWindow destructor**: Added `QCoreApplication::processEvents()` call after deleting network-related objects to process pending `deleteLater()` calls and prevent QThreadStorage warnings on exit
- **DownLoadCTY**: Changed QNetworkAccessManager to be parented to `this` and use `deleteLater()` instead of immediate `delete()`
- **eLogClubLog**: Changed manager deletion to use `deleteLater()` for safe cleanup
- **eLogQrzLog**: Added `deleteLater()` calls for both `manager` and `managerLog` network managers
- **LoTWUtilities**: Changed manager deletion to use `deleteLater()` for safe cleanup
- **Reordered cleanup**: Moved `delete(softUpdate)` earlier in MainWindow destructor to ensure proper cleanup order

## Implementation Details
The root cause of the QThreadStorage warnings is that QNetworkAccessManager uses thread-local storage internally. When these objects are deleted directly during application shutdown, it can trigger warnings. By using `deleteLater()` and processing pending events, we allow Qt's event loop to safely clean up these objects on their owning threads, preventing the warnings.

https://claude.ai/code/session_01LZkCS4LtZjnfP6hUkspxLk