### PR TITLE
Enable offscreen rendering for Qt tests in headless environments

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,3 +12,8 @@ endforeach()
 
 # Custom target to build all tests at once: cmake --build build --target build_tests
 add_custom_target(build_tests DEPENDS ${ALL_TEST_TARGETS})
+
+# Use offscreen platform so tests work without a display server (e.g. Debian build)
+foreach(target ${ALL_TEST_TARGETS})
+    set_tests_properties(${target} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+endforeach()


### PR DESCRIPTION
## Summary
Configure Qt tests to run with offscreen platform rendering, allowing tests to execute successfully in headless environments without a display server.

## Changes
- Added QT_QPA_PLATFORM environment variable configuration for all test targets
- Set the platform abstraction to "offscreen" mode for each test executable
- This enables tests to run in CI/CD pipelines and build systems without X11 or Wayland display servers

## Details
The change applies the `QT_QPA_PLATFORM=offscreen` environment variable to all test targets via CMake's `set_tests_properties()`. This is particularly useful for automated builds on systems like Debian build servers that may not have a graphical display available. The offscreen platform allows Qt applications to render to memory buffers instead of requiring an active display server.

https://claude.ai/code/session_0152Mqs5fD4Ck2MsfdBhmDTA