### PR TITLE
Fix set_tests_properties scope for offscreen Qt platform

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ endforeach()
 # Custom target to build all tests at once: cmake --build build --target build_tests
 add_custom_target(build_tests DEPENDS ${ALL_TEST_TARGETS})
 
-# Use offscreen platform so tests work without a display server (e.g. Debian build)
-foreach(target ${ALL_TEST_TARGETS})
-    set_tests_properties(${target} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
-endforeach()
+# NOTE: QT_QPA_PLATFORM=offscreen is set via set_tests_properties() in each
+# test subdirectory's CMakeLists.txt (right after add_test).  CMake's
+# set_tests_properties() only works on tests defined in the *same* directory
+# scope, so it must live in the subdirectory, not here.

--- a/tests/tst_adif/CMakeLists.txt
+++ b/tests/tst_adif/CMakeLists.txt
@@ -35,4 +35,5 @@ target_link_libraries(tst_adif
 
 # Register the test with CTest
 add_test(NAME tst_adif COMMAND tst_adif)
+set_tests_properties(tst_adif PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 

--- a/tests/tst_callsign/CMakeLists.txt
+++ b/tests/tst_callsign/CMakeLists.txt
@@ -33,4 +33,5 @@ target_link_libraries(tst_callsign
 
 # Register the test with CTest
 add_test(NAME tst_callsign COMMAND tst_callsign)
+set_tests_properties(tst_callsign PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 

--- a/tests/tst_database/CMakeLists.txt
+++ b/tests/tst_database/CMakeLists.txt
@@ -57,3 +57,4 @@ target_link_libraries(tst_database PRIVATE
 
 # Register the test with CTest
 add_test(NAME tst_database COMMAND tst_database)
+set_tests_properties(tst_database PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/tests/tst_datacache/CMakeLists.txt
+++ b/tests/tst_datacache/CMakeLists.txt
@@ -56,4 +56,5 @@ target_link_libraries(tst_datacache PRIVATE
 
 # Register the test with CTest
 add_test(NAME tst_datacache COMMAND tst_datacache)
+set_tests_properties(tst_datacache PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 

--- a/tests/tst_dataproxy/CMakeLists.txt
+++ b/tests/tst_dataproxy/CMakeLists.txt
@@ -56,4 +56,5 @@ target_link_libraries(tst_dataproxy
 
 # Register the test with CTest
 add_test(NAME tst_dataproxy COMMAND tst_dataproxy)
+set_tests_properties(tst_dataproxy PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 

--- a/tests/tst_dxcluster/CMakeLists.txt
+++ b/tests/tst_dxcluster/CMakeLists.txt
@@ -65,3 +65,4 @@ target_link_libraries(tst_dxcluster
 target_compile_definitions(tst_dxcluster PRIVATE KLOG_TESTING)
 
 add_test(NAME tst_dxcluster COMMAND tst_dxcluster)
+set_tests_properties(tst_dxcluster PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/tests/tst_dxspot/CMakeLists.txt
+++ b/tests/tst_dxspot/CMakeLists.txt
@@ -43,4 +43,5 @@ target_link_libraries(tst_dxspot
 
 # Register the test with CTest
 add_test(NAME tst_dxspot COMMAND tst_dxspot)
+set_tests_properties(tst_dxspot PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 

--- a/tests/tst_elogclublog/CMakeLists.txt
+++ b/tests/tst_elogclublog/CMakeLists.txt
@@ -35,3 +35,4 @@ target_link_libraries(tst_elogclublog
 )
 
 add_test(NAME tst_elogclublog COMMAND tst_elogclublog)
+set_tests_properties(tst_elogclublog PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/tests/tst_filemanager/CMakeLists.txt
+++ b/tests/tst_filemanager/CMakeLists.txt
@@ -65,4 +65,5 @@ target_link_libraries(tst_filemanager
 
 # Register the test with CTest
 add_test(NAME tst_filemanager COMMAND tst_filemanager)
+set_tests_properties(tst_filemanager PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 

--- a/tests/tst_frequency/CMakeLists.txt
+++ b/tests/tst_frequency/CMakeLists.txt
@@ -36,4 +36,5 @@ target_link_libraries(tst_frequency
 
 # Register the test with CTest
 add_test(NAME tst_frequency COMMAND tst_frequency)
+set_tests_properties(tst_frequency PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 

--- a/tests/tst_hamlib/CMakeLists.txt
+++ b/tests/tst_hamlib/CMakeLists.txt
@@ -92,3 +92,4 @@ target_link_libraries(tst_hamlib PRIVATE ${_tst_libs})
 
 # 6. Register the test
 add_test(NAME tst_hamlib COMMAND tst_hamlib)
+set_tests_properties(tst_hamlib PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/tests/tst_locator/CMakeLists.txt
+++ b/tests/tst_locator/CMakeLists.txt
@@ -36,4 +36,5 @@ target_link_libraries(tst_locator
 
 # Register the test with CTest
 add_test(NAME tst_locator COMMAND tst_locator)
+set_tests_properties(tst_locator PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 

--- a/tests/tst_logwindow/CMakeLists.txt
+++ b/tests/tst_logwindow/CMakeLists.txt
@@ -69,4 +69,5 @@ target_link_libraries(tst_logwindow
 
 # Register the test with CTest
 add_test(NAME tst_logwindow COMMAND tst_logwindow)
+set_tests_properties(tst_logwindow PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 

--- a/tests/tst_mainqsoentrywidget/CMakeLists.txt
+++ b/tests/tst_mainqsoentrywidget/CMakeLists.txt
@@ -60,4 +60,5 @@ target_link_libraries(tst_mainqsoentrywidget
 
 # Register the test with CTest
 add_test(NAME tst_mainqsoentrywidget COMMAND tst_mainqsoentrywidget)
+set_tests_properties(tst_mainqsoentrywidget PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 

--- a/tests/tst_mainwindow/CMakeLists.txt
+++ b/tests/tst_mainwindow/CMakeLists.txt
@@ -291,3 +291,4 @@ target_link_libraries(tst_mainwindow PRIVATE ${_tst_libs})
 
 # Register the test with CTest
 add_test(NAME tst_mainwindow COMMAND tst_mainwindow)
+set_tests_properties(tst_mainwindow PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/tests/tst_mainwindowinputothers/CMakeLists.txt
+++ b/tests/tst_mainwindowinputothers/CMakeLists.txt
@@ -61,4 +61,5 @@ target_link_libraries(tst_mainwindowinputothers
 
 # Register the test with CTest
 add_test(NAME tst_mainwindowinputothers COMMAND tst_mainwindowinputothers)
+set_tests_properties(tst_mainwindowinputothers PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 

--- a/tests/tst_mainwindowinputqso/CMakeLists.txt
+++ b/tests/tst_mainwindowinputqso/CMakeLists.txt
@@ -59,4 +59,5 @@ target_link_libraries(tst_mainwindowinputqso
 
 # Register the test with CTest
 add_test(NAME tst_mainwindowinputqso COMMAND tst_mainwindowinputqso)
+set_tests_properties(tst_mainwindowinputqso PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 

--- a/tests/tst_mainwindowsattab/CMakeLists.txt
+++ b/tests/tst_mainwindowsattab/CMakeLists.txt
@@ -61,4 +61,5 @@ target_link_libraries(tst_mainwindowsattab
 
 # Register the test with CTest
 add_test(NAME tst_mainwindowsattab COMMAND tst_mainwindowsattab)
+set_tests_properties(tst_mainwindowsattab PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 

--- a/tests/tst_qso/CMakeLists.txt
+++ b/tests/tst_qso/CMakeLists.txt
@@ -54,4 +54,5 @@ target_link_libraries(tst_qso
 
 # Register the test with CTest
 add_test(NAME tst_qso COMMAND tst_qso)
+set_tests_properties(tst_qso PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 

--- a/tests/tst_setuphamlibnetworkwidget/CMakeLists.txt
+++ b/tests/tst_setuphamlibnetworkwidget/CMakeLists.txt
@@ -34,4 +34,5 @@ target_link_libraries(tst_setuphamlibnetworkwidget
 
 # Register the test with CTest
 add_test(NAME tst_setuphamlibnetworkwidget COMMAND tst_setuphamlibnetworkwidget)
+set_tests_properties(tst_setuphamlibnetworkwidget PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 

--- a/tests/tst_setuphamlibserialwidget/CMakeLists.txt
+++ b/tests/tst_setuphamlibserialwidget/CMakeLists.txt
@@ -35,4 +35,5 @@ target_link_libraries(tst_setuphamlibserialwidget
 
 # Register the test with CTest
 add_test(NAME tst_setuphamlibserialwidget COMMAND tst_setuphamlibserialwidget)
+set_tests_properties(tst_setuphamlibserialwidget PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 

--- a/tests/tst_setuppageelog/CMakeLists.txt
+++ b/tests/tst_setuppageelog/CMakeLists.txt
@@ -57,4 +57,5 @@ target_link_libraries(tst_setuppageelog
 
 # Register the test with CTest
 add_test(NAME tst_setuppageelog COMMAND tst_setuppageelog)
+set_tests_properties(tst_setuppageelog PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 

--- a/tests/tst_utilities/CMakeLists.txt
+++ b/tests/tst_utilities/CMakeLists.txt
@@ -55,4 +55,5 @@ target_link_libraries(tst_utilities
 
 # Register the test with CTest
 add_test(NAME tst_utilities COMMAND tst_utilities)
+set_tests_properties(tst_utilities PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 

--- a/tests/tst_wizard/CMakeLists.txt
+++ b/tests/tst_wizard/CMakeLists.txt
@@ -44,4 +44,5 @@ target_link_libraries(tst_wizard
 
 # Register the test with CTest
 add_test(NAME tst_wizard COMMAND tst_wizard)
+set_tests_properties(tst_wizard PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 

--- a/tests/tst_world/CMakeLists.txt
+++ b/tests/tst_world/CMakeLists.txt
@@ -56,4 +56,5 @@ target_link_libraries(tst_world
 
 # Register the test with CTest
 add_test(NAME tst_world COMMAND tst_world)
+set_tests_properties(tst_world PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 


### PR DESCRIPTION
## Summary
- Fix `QT_QPA_PLATFORM=offscreen` not actually being applied to tests during Debian builds
- Move `set_tests_properties()` from parent `tests/CMakeLists.txt` into each test's own `CMakeLists.txt`

## Problem
The previous fix (PR #954) added `set_tests_properties()` in `tests/CMakeLists.txt`, but CMake's `set_tests_properties()` only works on tests defined in the **same directory scope**. Since each test registers itself via `add_test()` in its own subdirectory, the parent-level call silently had no effect — causing 18 of 25 tests to fail with `could not connect to display` / `Could not load the Qt platform plugin "xcb"`.

## Fix
Place `set_tests_properties(<test> PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")` right after `add_test()` in each of the 25 test subdirectory `CMakeLists.txt` files, where it correctly takes effect.

## Test plan
- [ ] Rebuild the Debian package (`debuild -us -uc -ui`) and verify all 25 tests pass
- [ ] Verify tests still pass on systems with a display server

https://claude.ai/code/session_0152Mqs5fD4Ck2MsfdBhmDTA