### PR TITLE
fix: prevent tst_filemanager hang in headless Debian builds

### DIFF
--- a/tests/tst_filemanager/tst_filemanager.cpp
+++ b/tests/tst_filemanager/tst_filemanager.cpp
@@ -186,13 +186,17 @@ void tst_FileManager::test_ADIF_Import_invalidLogN_fallsBackToExistingLog()
     int maxLog = dataProxy->getMaxLogNumber();
     QVERIFY2(maxLog > 0, "There must be at least one log for the fallback test");
 
+    // Remove QSOs left by previous tests so the import is not treated as a
+    // duplicate.  adifReadLog shows a blocking QMessageBox when it finds
+    // duplicates, which hangs the test in a headless (offscreen) environment.
+    QSqlQuery cleanup;
+    cleanup.exec("DELETE FROM log");
+
     int qsosBefore = dataProxy->getHowManyQSOInLog(maxLog);
 
     // logN=-1: adifReadLog must fall back to the highest existing log, not reject
     int imported = fileManager->adifReadLog(adifFilePath, "EA4K", -1);
-    // The call may return -2 (duplicate) if the QSO was already imported in
-    // the previous test; what matters is it did NOT return -3 (no-logs error)
-    // and that no QSO got stored with lognumber=-1.
+    // The call must return >0 (the fallback succeeded and the QSO was imported).
     QVERIFY2(imported != -3,
              "adifReadLog returned -3 (no logs), but a log exists — fallback failed (#903)");
 


### PR DESCRIPTION
## Summary
- Fix `tst_filemanager` hanging forever during headless Debian package builds

## Problem
`test_ADIF_Import_invalidLogN_fallsBackToExistingLog` imports the same ADIF file that `test_ADIF_Import_setsCorrectLogNumber` had already imported. `adifReadLog` detects the duplicate and calls `showDuplicatedQSOFoundInLog()` → `QMessageBox::exec()`, which blocks forever in a headless (offscreen) environment because no user can click the dialog.

## Fix
Delete the QSOs left by the previous test before running the second import, so no duplicate is detected and no blocking dialog is shown. The test's actual goal — verifying that `logN=-1` falls back to the highest existing log and does not return `-3` — is still fully covered.

## Test plan
- [ ] Rebuild the Debian package (`debuild -us -uc -ui`) and verify all 25 tests pass without hanging
- [ ] Confirm `tst_filemanager` passes all three regression tests for issue #903

https://claude.ai/code/session_0152Mqs5fD4Ck2MsfdBhmDTA