### PR TITLE
Fix docs installing to /usr/share/doc/KLog/ instead of /usr/share/doc/klog/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,9 +68,10 @@ qt_standard_project_setup()
 if(UNIX AND NOT APPLE)
     include(GNUInstallDirs)
     # Debian Policy §12.3: docs must live under share/doc/<lowercase-package>.
-    # Override the CMake default, which would use PROJECT_NAME = "KLog" (uppercase).
-    set(CMAKE_INSTALL_DOCDIR "${CMAKE_INSTALL_DATADIR}/doc/klog"
-    CACHE PATH "Documentation root (FHS: share/doc/klog)")
+    # GNUInstallDirs already cached CMAKE_INSTALL_DOCDIR with PROJECT_NAME
+    # ("KLog", uppercase).  A plain set() shadows the cache value so the
+    # lowercase "klog" is always used regardless of cache state.
+    set(CMAKE_INSTALL_DOCDIR "${CMAKE_INSTALL_DATADIR}/doc/klog")
 endif()
 
 


### PR DESCRIPTION
## Summary

- Fix `CMAKE_INSTALL_DOCDIR` not taking effect because `GNUInstallDirs` caches it first with uppercase `PROJECT_NAME` ("KLog")
- Change from `set(... CACHE ...)` (no-op when already cached) to a plain `set()` that always shadows the cache value
- Docs now consistently install to `/usr/share/doc/klog/` (lowercase) on all Linux builds (Debian, Mageia, etc.)

## Problem

`include(GNUInstallDirs)` sets `CMAKE_INSTALL_DOCDIR` as a cache variable using `PROJECT_NAME` = "KLog" (uppercase). The subsequent `set(CMAKE_INSTALL_DOCDIR "share/doc/klog" CACHE ...)` was silently ignored because CMake's `set(... CACHE ...)` is a no-op when the variable already exists in the cache. This caused:

- Debian: docs duplicated in both `/usr/share/doc/KLog/` and `/usr/share/doc/klog/`
- Mageia: build failure because RPM spec expects `/usr/share/doc/klog`

## Test plan

- [ ] Rebuild Debian package and verify `dpkg -L klog` shows only `/usr/share/doc/klog/` (no uppercase KLog)
- [ ] Rebuild Mageia RPM and verify `/usr/share/doc/klog` is created correctly

https://claude.ai/code/session_0152Mqs5fD4Ck2MsfdBhmDTA