### PR TITLE
Refactor documentation installation for platform-specific handling

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -241,9 +241,8 @@ set(KLOG_DOC_LINUX
    ../TROUBLESHOOTING
 )
 
-install(FILES ${KLOG_DOC_LINUX}
-   DESTINATION ${CMAKE_INSTALL_DOCDIR}
-)
+# Linux docs are installed inside the platform-specific else() block below;
+# macOS and Windows handle their own doc sets in their respective branches.
 
 set(KLOG_MAN
     klog.1
@@ -407,7 +406,7 @@ else()
     # Documentation: /usr/share/doc/klog/
     # Debian Policy §12.3: all package docs go under /usr/share/doc/<package>.
     # Only install docs relevant on Linux; exclude Windows/macOS install guides.
-    install(FILES ${KLOG_DOC} ${KLOG_DOC_LINUX}
+    install(FILES ${KLOG_DOC_LINUX}
         DESTINATION ${CMAKE_INSTALL_DOCDIR}
     )
 


### PR DESCRIPTION
## Summary
Reorganized the CMake documentation installation logic to properly handle platform-specific doc sets. Removed the generic Linux documentation installation block and consolidated it within the Linux-specific conditional branch.

## Key Changes
- Removed the unconditional `install(FILES ${KLOG_DOC_LINUX} ...)` block that was executing for all platforms
- Added clarifying comments explaining that macOS and Windows handle their own documentation installation in their respective conditional branches
- Updated the Linux-specific installation block to only install `${KLOG_DOC_LINUX}` (removed the redundant `${KLOG_DOC}` variable that was being installed alongside it)

## Implementation Details
- The documentation installation is now properly scoped within the `else()` block that handles Linux-specific configuration
- This prevents documentation files from being installed multiple times or in incorrect locations on non-Linux platforms
- The change maintains the same installation destination (`${CMAKE_INSTALL_DOCDIR}`) for Linux while allowing other platforms to define their own installation strategies

https://claude.ai/code/session_011aNHHFKkJeF7cNA3DB5Xhu