### PR TITLE
Fix file handling and transaction management in ADIF log reading

### DIFF
--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -630,7 +630,7 @@ int FileManager::adifLoTWReadLog2(const QString& fileName, const int logN)
             pos = file.pos();
         }
     }
-    file.seek(pos);
+    file.close();
     //qDebug() << Q_FUNC_INFO << " - END" ;
     return adifReadLog(fileName, stationCallSign, logN);
 }
@@ -929,7 +929,10 @@ int FileManager::adifReadLog(const QString& tfileName, QString _stationCallsign,
         }
     }
 
-    dataProxy->commitTransaction();
+    if (noMoreQSO)
+        dataProxy->rollbackTransaction();
+    else
+        dataProxy->commitTransaction();
     dataProxy->clearDuplicateCache();
     file.close();
     progress.setValue(qsos);


### PR DESCRIPTION
## Summary
This PR fixes two issues in the ADIF log file reading functionality:
1. Properly closes the file handle after reading LoTW logs
2. Implements conditional transaction handling based on whether QSOs were successfully read

## Key Changes
- **File handle management**: Changed `file.seek(pos)` to `file.close()` in `adifLoTWReadLog2()` to properly release the file resource after reading
- **Transaction handling**: Modified `adifReadLog()` to rollback the database transaction if no QSOs were read (`noMoreQSO` flag), otherwise commit as normal

## Implementation Details
The transaction rollback on empty reads prevents database state corruption when a log file contains no valid QSO records, while the file close fix ensures proper resource cleanup in the LoTW log reading path.

https://claude.ai/code/session_019MPCR8Sg9jcuWKAM5G392F