### PR TITLE
Prevent signal emission when setting manual mode checkbox

### DIFF
--- a/src/mainqsoentrywidget.cpp
+++ b/src/mainqsoentrywidget.cpp
@@ -910,7 +910,9 @@ void MainQSOEntryWidget::setManualMode(const bool _manualMode)
 {
     logEvent (Q_FUNC_INFO, "Start", Debug);
    //qDebug()<< Q_FUNC_INFO;
+    manualModeCheckBox->blockSignals(true);
     manualModeCheckBox->setChecked (_manualMode);
+    manualModeCheckBox->blockSignals(false);
     logEvent (Q_FUNC_INFO, "END", Debug);
 }
 


### PR DESCRIPTION
## Summary
Block signals on the manual mode checkbox during state updates to prevent unintended signal cascades when programmatically setting the checkbox state.

## Key Changes
- Wrap `manualModeCheckBox->setChecked()` call with `blockSignals(true)` and `blockSignals(false)` in the `setManualMode()` method
- This prevents the checkbox's state-changed signals from being emitted when the checked state is set programmatically

## Implementation Details
The checkbox signals are temporarily blocked before updating the checked state and re-enabled immediately after. This is a common pattern to prevent recursive or unwanted signal handling when updating UI elements programmatically, ensuring that only user-initiated checkbox changes trigger downstream logic.

https://claude.ai/code/session_01Y8sVb9FDMxhPsAfxY4ZpP9