### PR TITLE
Optimize startup performance with lazy initialization and background cache loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 
 # Find required Qt6 modules
 find_package(Qt6 REQUIRED COMPONENTS
-    Charts Core Gui Location Network Positioning
+    Charts Concurrent Core Gui Location Network Positioning
     PrintSupport Qml Quick QuickWidgets SerialPort Sql Widgets
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -308,6 +308,7 @@ endif()
 target_link_libraries(klog
   PRIVATE
     Qt6::Charts
+    Qt6::Concurrent
     Qt6::Core
     Qt6::Gui
     Qt6::Location

--- a/src/awards.cpp
+++ b/src/awards.cpp
@@ -50,11 +50,11 @@ Awards::Awards(DataProxy_SQLite *dp, World *injectedWorld, const QString &_paren
     //"Awards::setColors: " << _newOne << "/" << _needed << "/" << _worked << "/" << _confirmed << "/" << _default;
     //Awards::setColors:  "#ff0000" / "#ff8c00" / "#ffd700" / "#32cd32" / "#00bfff"
 
-    newOneColor = Qt::black;
-    neededColor = Qt::black;
-    workedColor = Qt::black;
-    confirmedColor = Qt::black;
-    defaultColor = Qt::black;
+    newOneColor   = KLOG_COLOR_NEW_ONE;
+    neededColor   = KLOG_COLOR_NEEDED;
+    workedColor   = KLOG_COLOR_WORKED;
+    confirmedColor = KLOG_COLOR_CONFIRMED;
+    defaultColor  = KLOG_COLOR_DEFAULT;
 
     dxccWorked.clear();
     dxccConfirmed.clear();

--- a/src/dataproxy_sqlite.cpp
+++ b/src/dataproxy_sqlite.cpp
@@ -175,7 +175,7 @@ void DataProxy_SQLite::ensureCacheReady()
         m_cache.addMode(m.id, m.submode, m.mode, m.cabrillo, m.deprecated);
     for (const auto &e : data.entities)
         m_cache.addEntity(e.dxcc, e.name);
-    qInfo() << "[KLOG-TIMING] ensureCacheReady: cache populated"
+   //qInfo() << "[KLOG-TIMING] ensureCacheReady: cache populated"
             << "(bands:" << data.bands.size()
             << "modes:" << data.modes.size()
             << "entities:" << data.entities.size() << ")";

--- a/src/dataproxy_sqlite.cpp
+++ b/src/dataproxy_sqlite.cpp
@@ -183,8 +183,6 @@ void DataProxy_SQLite::ensureCacheReady()
 // ---------------------------------------------------------------------------
 
 // DEPRECATED: replaced by loadCacheBG() + ensureCacheReady() (background-thread loading).
-// Kept for reference only; do not call.
-[[deprecated("Replaced by loadCacheBG() + ensureCacheReady(). Do not call.")]]
 bool DataProxy_SQLite::createHashes()
 {
     logEvent (Q_FUNC_INFO, "Start", Debug);

--- a/src/dataproxy_sqlite.cpp
+++ b/src/dataproxy_sqlite.cpp
@@ -28,6 +28,9 @@
 #include "callsign.h"
 #include "adif.h"
 #include "locator.h"
+#include <QtConcurrent>
+#include <QSqlDatabase>
+#include <QThread>
 
 static QString buildModeInClause(const QList<int> &modeIds)
 {
@@ -60,15 +63,10 @@ DataProxy_SQLite::DataProxy_SQLite(const QString &_parentFunction, const QString
     //qDebug() << Q_FUNC_INFO << " - 49";
 
     dbCreated = db->createConnection(Q_FUNC_INFO);
-    //qDebug() << Q_FUNC_INFO << " - 50";
 
-     //qDebug() << Q_FUNC_INFO << " - 51";
-        //util->setSpecialCalls(getSpecialCallsigns());
-     //qDebug() << Q_FUNC_INFO << " - 52";
-    //qso = new QSO;
-    //qDebug() << Q_FUNC_INFO << " - 53";
-    createHashes();
-    //loadBandLimits();
+    // [PROPOSAL-6] Launch cache loading in a background thread using its own SQLite connection.
+    // ensureCacheReady() (called lazily from any cache-using method) will wait for it to finish.
+    m_cacheFuture = QtConcurrent::run(&DataProxy_SQLite::loadCacheBG, util->getKLogDBFile());
     searching = false;
     executionN = 0;
     connections = connect(db, SIGNAL(debugLog(QString, QString, DebugLogLevel)), this, SLOT(slotCaptureDebugLogs(QString, QString, DebugLogLevel)) );
@@ -84,7 +82,7 @@ DataProxy_SQLite::DataProxy_SQLite(const QString &_parentFunction, const QString
     util->setVersion(_softVersion);
     db = new DataBase(Q_FUNC_INFO, _softVersion, _dbPath);
     dbCreated = db->createConnection(Q_FUNC_INFO);
-    createHashes();
+    m_cacheFuture = QtConcurrent::run(&DataProxy_SQLite::loadCacheBG, _dbPath);
     searching = false;
     executionN = 0;
     connections = connect(db, SIGNAL(debugLog(QString, QString, DebugLogLevel)), this, SLOT(slotCaptureDebugLogs(QString, QString, DebugLogLevel)));
@@ -101,6 +99,88 @@ DataProxy_SQLite::~DataProxy_SQLite()
     delete db;
     delete util;
 }
+
+// ---------------------------------------------------------------------------
+// Background cache loader (Proposal 6)
+// Opens its own named SQLite connection so it can run safely in a worker thread.
+// ---------------------------------------------------------------------------
+DataProxy_SQLite::CacheLoadResult DataProxy_SQLite::loadCacheBG(const QString &dbPath)
+{
+    CacheLoadResult result;
+    const QString connName = QString("klog_cache_bg_%1")
+                                 .arg(reinterpret_cast<quintptr>(QThread::currentThread()), 0, 16);
+    {
+        QSqlDatabase bgDb = QSqlDatabase::addDatabase("QSQLITE", connName);
+        bgDb.setDatabaseName(dbPath);
+        if (!bgDb.open()) {
+            QSqlDatabase::removeDatabase(connName);
+            qWarning() << "[KLOG-TIMING] loadCacheBG: failed to open DB at" << dbPath;
+            return result;
+        }
+
+        QSqlQuery q(bgDb);
+
+        if (q.exec("SELECT id, name, lower, upper FROM band")) {
+            while (q.next()) {
+                Frequency fmin, fmax;
+                fmin.fromDouble(q.value(2).toDouble(), MHz);
+                fmax.fromDouble(q.value(3).toDouble(), MHz);
+                BandEntry be;
+                be.id = q.value(0).toInt();
+                be.name = q.value(1).toString();
+                be.minFreq = fmin;
+                be.maxFreq = fmax;
+                result.bands.append(be);
+            }
+        }
+
+        if (q.exec("SELECT id, submode, name, cabrillo, deprecated FROM mode")) {
+            while (q.next()) {
+                ModeEntry me;
+                me.id       = q.value(0).toInt();
+                me.submode  = q.value(1).toString();
+                me.mode     = q.value(2).toString();
+                me.cabrillo = q.value(3).toString();
+                me.deprecated = q.value(4).toBool();
+                result.modes.append(me);
+            }
+        }
+
+        if (q.exec("SELECT dxcc, name FROM entity")) {
+            while (q.next()) {
+                EntityEntry ee;
+                ee.dxcc = q.value(0).toInt();
+                ee.name = q.value(1).toString();
+                result.entities.append(ee);
+            }
+        }
+
+        result.ok = !result.bands.isEmpty() && !result.modes.isEmpty();
+        bgDb.close();
+    }
+    QSqlDatabase::removeDatabase(connName);
+    return result;
+}
+
+// Called by every public method that reads m_cache.
+// On first call, waits for the background thread (usually already done) and populates m_cache.
+void DataProxy_SQLite::ensureCacheReady()
+{
+    if (m_cachePopulated) return;
+    m_cachePopulated = true;
+    const CacheLoadResult data = m_cacheFuture.result(); // blocks only if BG not finished yet
+    for (const auto &b : data.bands)
+        m_cache.addBand(b.id, b.name, b.minFreq, b.maxFreq);
+    for (const auto &m : data.modes)
+        m_cache.addMode(m.id, m.submode, m.mode, m.cabrillo, m.deprecated);
+    for (const auto &e : data.entities)
+        m_cache.addEntity(e.dxcc, e.name);
+    qInfo() << "[KLOG-TIMING] ensureCacheReady: cache populated"
+            << "(bands:" << data.bands.size()
+            << "modes:" << data.modes.size()
+            << "entities:" << data.entities.size() << ")";
+}
+// ---------------------------------------------------------------------------
 
 bool DataProxy_SQLite::createHashes()
 {
@@ -308,8 +388,8 @@ int DataProxy_SQLite::getIdFromModeName(const QString& _modeName)
 {
     logEvent (Q_FUNC_INFO, "Start", Debug);
     if (_modeName.length() < 2) return -4;
-        return m_cache.getModeIdFromSubmode(_modeName);
-    //return db->getModeIdFromSubMode(_modeName);
+    ensureCacheReady();
+    return m_cache.getModeIdFromSubmode(_modeName);
 }
 
 bool DataProxy_SQLite::isValidMode(const QString& _modeName)
@@ -326,37 +406,40 @@ bool DataProxy_SQLite::isModeDeprecated (const QString &_sm)
 {
     logEvent (Q_FUNC_INFO, "Start", Debug);
     if (_sm.length() < 2) return false;
+    ensureCacheReady();
     return m_cache.isModeDeprecated(_sm);
 }
 
 int DataProxy_SQLite::getIdFromBandName(const QString& _bandName)
 {
-    //logEvent (Q_FUNC_INFO, "Start", Debug);
+    ensureCacheReady();
     return m_cache.getBandFromName(_bandName).id;
 }
 
 QString DataProxy_SQLite::getNameFromBandId (const int _id)
-{ //TODO: Use the hash
-    //logEvent(Q_FUNC_INFO, "Start", Devel);
+{
+    ensureCacheReady();
     return m_cache.getBandFromId(_id).name;
 }
 
 QString DataProxy_SQLite::getNameFromModeId (const int _id)
-{ //TODO: Use the hash
+{
     logEvent (Q_FUNC_INFO, "Start-End", Debug);
+    ensureCacheReady();
     return m_cache.getModeFromId(_id).mode;
-    //return db->getModeNameFromNumber(_id);
 }
 
 QString DataProxy_SQLite::getSubModeFromId (const int _id)
 {
     logEvent (Q_FUNC_INFO, "Start", Debug);
+    ensureCacheReady();
     return m_cache.getModeFromId(_id).submode;
 }
 
 QString DataProxy_SQLite::getNameFromSubMode (const QString &_sm)
 {
     logEvent (Q_FUNC_INFO, "Start", Debug);
+    ensureCacheReady();
     return m_cache.getModeNameFromSubmode(_sm);
 }
 
@@ -364,6 +447,7 @@ QList<int> DataProxy_SQLite::getModeGroupIds(const int _modeId)
 {
     // Returns all mode IDs that share the same parent mode as _modeId
     // e.g. for USB (parent=SSB) returns IDs of SSB, USB, LSB
+    ensureCacheReady();
     const QString parentMode = m_cache.getModeFromId(_modeId).mode;
     if (parentMode.isEmpty())
         return QList<int>() << _modeId;
@@ -384,36 +468,36 @@ QList<int> DataProxy_SQLite::getModeGroupIds(const int _modeId)
 
 int DataProxy_SQLite::getBandIdFromFreq(const Frequency _n)
 {
-    // Replaced the heavy SQL query with a fast in-memory lookup.
-
     logEvent (Q_FUNC_INFO, "Start", Debug);
+    ensureCacheReady();
     return m_cache.getBandFromFreq (_n).id;
 }
-
-
 
 QString DataProxy_SQLite::getBandNameFromFreq(const Frequency _n)
 {
     logEvent (Q_FUNC_INFO, "Start", Debug);
-        return m_cache.getBandFromFreq(_n).name;
+    ensureCacheReady();
+    return m_cache.getBandFromFreq(_n).name;
 }
 
 Frequency DataProxy_SQLite::getLowLimitBandFromBandName(const QString &_sm)
 {
     logEvent (Q_FUNC_INFO, "Start", Debug);
+    ensureCacheReady();
     return m_cache.getBandFromName(_sm).minFreq;
 }
 
 Frequency DataProxy_SQLite::getLowLimitBandFromBandId(const int _sm)
 {
     logEvent (Q_FUNC_INFO, "Start", Debug);
+    ensureCacheReady();
     return m_cache.getBandFromId(_sm).minFreq;
 }
 
 Frequency DataProxy_SQLite::getUpperLimitBandFromBandName(const QString &_sm)
 {
-    //qDebug() << Q_FUNC_INFO << ": " << _sm;
-        return m_cache.getBandFromName(_sm).maxFreq;
+    ensureCacheReady();
+    return m_cache.getBandFromName(_sm).maxFreq;
 }
 
 
@@ -460,8 +544,7 @@ bool DataProxy_SQLite::loadBandLimits()
 
 bool DataProxy_SQLite::isThisFreqInBand(const QString &_band, const Frequency _fr)
 {
-    //qDebug() << Q_FUNC_INFO << " - Band: " << _band;
-    //qDebug() << Q_FUNC_INFO << " - BandC: " << m_cache.getBandFromFreq(_fr).name;
+    ensureCacheReady();
     return (m_cache.getBandFromFreq(_fr).name == _band );
 }
 
@@ -3416,21 +3499,23 @@ int DataProxy_SQLite::isThisQSODuplicated (const QSO &_qso, const int _secs)
 }
 
 bool DataProxy_SQLite::isHF(const int _band)
-{// 160M is considered as HF
+{
+    ensureCacheReady();
     const BandEntry b = m_cache.getBandFromId(_band);
-
     if (!b.isValid()) return false;
-      return b.minFreq >= Frequency(1.8, MHz) && b.maxFreq <= Frequency(30.0, MHz);
+    return b.minFreq >= Frequency(1.8, MHz) && b.maxFreq <= Frequency(30.0, MHz);
 }
 
 bool DataProxy_SQLite::isWARC(const int _band)
 {
+    ensureCacheReady();
     const QString name = m_cache.getBandFromId(_band).name;
     return name == "30M" || name == "17M" || name == "12M";
 }
 
 bool DataProxy_SQLite::isVHF(const int _band)
 {
+    ensureCacheReady();
     const BandEntry b = m_cache.getBandFromId(_band);
     if (!b.isValid()) return false;
     return b.minFreq >= Frequency(40.0, MHz) && b.maxFreq <= Frequency(300.0, MHz);
@@ -3438,6 +3523,7 @@ bool DataProxy_SQLite::isVHF(const int _band)
 
 bool DataProxy_SQLite::isUHF(const int _band)
 {
+    ensureCacheReady();
     const BandEntry b = m_cache.getBandFromId(_band);
     if (!b.isValid()) return false;
     return b.minFreq >= Frequency(300.0, MHz) && b.maxFreq <= Frequency(3000.0, MHz);
@@ -7264,8 +7350,8 @@ int DataProxy_SQLite::getITUzFromEntity(const int _n)
 
 QString DataProxy_SQLite::getEntityNameFromId(const int _n)
 {
-  //qDebug() << Q_FUNC_INFO << " - " << QString::number(_n);
     logEvent (Q_FUNC_INFO, "Start", Debug);
+    ensureCacheReady();
     return m_cache.getEntityNameFromDXCC(_n);
  /*
 

--- a/src/dataproxy_sqlite.cpp
+++ b/src/dataproxy_sqlite.cpp
@@ -7844,51 +7844,28 @@ bool DataProxy_SQLite::getFreqHashData()
 
 QHash<QString, int> DataProxy_SQLite::getWorldData()
 {
-    //qDebug() << Q_FUNC_INFO << "Start";
     QHash<QString, int> world;
-    world.clear();
-
-    QString queryString;
     QSqlQuery query;
-    //query.setForwardOnly(true);
-    QString pref;
+    query.setForwardOnly(true);
 
-    queryString = "SELECT prefix, dxcc FROM prefixesofentity";
-    bool sqlOK = query.exec(queryString);
+    // Lets see how many prefixes do we have
+    QSqlQuery countQuery("SELECT COUNT(*) FROM prefixesofentity");
+    if (countQuery.next()) {
+        world.reserve(countQuery.value(0).toInt());
+    }
 
-    if (!sqlOK)
-    {
+    // Optimized query
+    QString queryString = "SELECT CASE WHEN substr(prefix, 1, 1) = '=' THEN substr(prefix, 2) ELSE prefix END, dxcc FROM prefixesofentity";
+
+    if (!query.exec(queryString)) {
         emit queryError(Q_FUNC_INFO, query.lastError().databaseText(), query.lastError().text(), query.lastQuery());
-        query.finish();
-       //qDebug() << Q_FUNC_INFO << "END-FAIL-1 - !sqlOK";
         return world;
     }
-    else
-    {
-        while ( (query.next()))
-        {
-            if (query.isValid())
-            {
-               //qDebug() << Q_FUNC_INFO << QString("Pref/Ent = %1/%2").arg((query.value(0)).toString()).arg((query.value(1)).toInt());
-                pref = (query.value(0)).toString();
-                if (pref.startsWith('='))
-                {
-                    pref.remove(0,1);
-                }
-                world.insert(pref, (query.value(1)).toInt());
-            }
-            else
-            {
-                query.finish();
-                world.clear();
-               //qDebug() << Q_FUNC_INFO << "END-FAIL - Query not valid";
-                return world;
-            }
-        }
+
+    while (query.next()) {
+        world.insert(query.value(0).toString(), query.value(1).toInt());
     }
-    query.finish();
-    //qDebug() << Q_FUNC_INFO << "END";
-   //qDebug() << Q_FUNC_INFO << ": count: " << QString::number(world.count());
+
     return world;
 }
 

--- a/src/dataproxy_sqlite.cpp
+++ b/src/dataproxy_sqlite.cpp
@@ -182,6 +182,9 @@ void DataProxy_SQLite::ensureCacheReady()
 }
 // ---------------------------------------------------------------------------
 
+// DEPRECATED: replaced by loadCacheBG() + ensureCacheReady() (background-thread loading).
+// Kept for reference only; do not call.
+[[deprecated("Replaced by loadCacheBG() + ensureCacheReady(). Do not call.")]]
 bool DataProxy_SQLite::createHashes()
 {
     logEvent (Q_FUNC_INFO, "Start", Debug);

--- a/src/dataproxy_sqlite.h
+++ b/src/dataproxy_sqlite.h
@@ -92,11 +92,12 @@ public:
     bool isValidBand(const QString& _bandName);
 
     //int getModeIdFromSubModeId(const int _sm);
-    // CACHE & HASH functios
-    bool createHashes();      // Creates a list of hashes for quick search (band/id & mode/id)
-    void loadBandDataCache(); // Creates the bands cache
-    void loadModeDataCache(); // Creates the modes cache
-    void loadEntityDataCache(); // Creates the Entitycache
+    // CACHE & HASH functions — superseded by loadCacheBG() + ensureCacheReady() (background thread)
+    [[deprecated("Replaced by loadCacheBG() + ensureCacheReady(). Do not call.")]]
+    bool createHashes();
+    void loadBandDataCache();   // internal: called only by createHashes()
+    void loadModeDataCache();   // internal: called only by createHashes()
+    void loadEntityDataCache(); // internal: called only by createHashes()
 
     QStringList getFields();
     //KLOG_DEPRECATED QStringList getBands();

--- a/src/dataproxy_sqlite.h
+++ b/src/dataproxy_sqlite.h
@@ -34,6 +34,8 @@
 #include <QPair>
 #include <QMultiHash>
 #include <QDateTime>
+#include <QFuture>
+#include <QList>
 
 #include "global.h"
 #include "database/database.h"
@@ -443,7 +445,19 @@ private:
     //KLOG_DEPRECATED QHash<QString, int> bandIDs;          // Move to DataCache
     //KLOG_DEPRECATED QHash<QString, int> modeIDs;          // Move to DataCache
 
-    DataCache m_cache; // Bands/Modes/Entity cache
+    DataCache m_cache; // Bands/Modes/Entity cache — populated lazily via ensureCacheReady()
+
+    // Background cache loading (Proposal 6)
+    struct CacheLoadResult {
+        QList<BandEntry> bands;
+        QList<ModeEntry> modes;
+        QList<EntityEntry> entities;
+        bool ok = false;
+    };
+    static CacheLoadResult loadCacheBG(const QString &dbPath); // Runs in a worker thread
+    void ensureCacheReady();   // Waits for background load and populates m_cache (idempotent)
+    QFuture<CacheLoadResult> m_cacheFuture;
+    bool m_cachePopulated = false;
 
     //KLOG_DEPRECATED QHash<int, QString> modeIdToName;         // Move to DataCache
     //KLOG_DEPRECATED QHash<QString, QList<int>> nameToModeIds; // Move to DataCache

--- a/src/dataproxy_sqlite.h
+++ b/src/dataproxy_sqlite.h
@@ -93,8 +93,7 @@ public:
 
     //int getModeIdFromSubModeId(const int _sm);
     // CACHE & HASH functions — superseded by loadCacheBG() + ensureCacheReady() (background thread)
-    [[deprecated("Replaced by loadCacheBG() + ensureCacheReady(). Do not call.")]]
-    bool createHashes();
+    KLOG_DEPRECATED bool createHashes();
     void loadBandDataCache();   // internal: called only by createHashes()
     void loadModeDataCache();   // internal: called only by createHashes()
     void loadEntityDataCache(); // internal: called only by createHashes()

--- a/src/hamlibclass.cpp
+++ b/src/hamlibclass.cpp
@@ -61,7 +61,7 @@ void HamLibClass::initClass()
     logEvent(Q_FUNC_INFO, "Start", Devel);
     rig_set_debug(RIG_DEBUG_ERR);
     strings.clear();
-    fillRigsList();
+    // fillRigsList() removed — rig list now loaded lazily on first getRigList() call
 
     connect(timer, &QTimer::timeout, this, &HamLibClass::slotTimer);
     clean();
@@ -649,6 +649,8 @@ bool HamLibClass::isRunning()
 
 void HamLibClass::fillRigsList()
 {
+    if (m_rigsLoaded)
+        return;
     logEvent(Q_FUNC_INFO, "Start", Devel);
     //qDebug() << "HamLibClass::getRigList: StringsList before filling it: ";
     // Rutine to fill the rig combo boxes
@@ -665,6 +667,7 @@ void HamLibClass::fillRigsList()
     rig_list_foreach(addRigToList, this);
     //qDebug() << "HamLibClass::getRigList-11";
     strings.sort();
+    m_rigsLoaded = true;
 }
 
 QStringList HamLibClass::getRigList()
@@ -672,8 +675,7 @@ QStringList HamLibClass::getRigList()
     logEvent(Q_FUNC_INFO, "Start", Devel);
     //qDebug() << "HamLibClass::getRigList: StringsList before filling it: ";
 
-    //fillRigsList ();
-    //strings.sort();
+    fillRigsList();  // loads only on first call (guarded by m_rigsLoaded)
     //qDebug() << "HamLibClass::getRigList-12 - Strings length: "
     //<< QString::number(strings.length());
     return strings;

--- a/src/hamlibclass.h
+++ b/src/hamlibclass.h
@@ -183,6 +183,7 @@ private:
     bool reading; // Just a semaphore to prevent several readings
     bool vfoQuerySupported;
     bool splitQuerySupported;
+    bool m_rigsLoaded = false;
     RadioStatus radioStatus;
 };
 

--- a/src/klogdefinitions.h
+++ b/src/klogdefinitions.h
@@ -39,7 +39,7 @@ inline const QColor KLOG_COLOR_CONFIRMED { QColor("#32CD32") };  // Lime     –
 inline const QColor KLOG_COLOR_DEFAULT   { QColor("#00BFFF") };  // Sky blue – Default / unknown
 
 // Alpha value for locator overlays on the map: ~31% opaque (69% transparent).
-inline constexpr int KLOG_LOCATOR_ALPHA = 80;
+inline constexpr int KLOG_LOCATOR_ALPHA = 100;
 
 //using namespace std;
 

--- a/src/klogdefinitions.h
+++ b/src/klogdefinitions.h
@@ -38,8 +38,8 @@ inline const QColor KLOG_COLOR_WORKED    { QColor("#FFD700") };  // Gold     –
 inline const QColor KLOG_COLOR_CONFIRMED { QColor("#32CD32") };  // Lime     – Confirmed
 inline const QColor KLOG_COLOR_DEFAULT   { QColor("#00BFFF") };  // Sky blue – Default / unknown
 
-// Alpha value for locator overlays on the map: ~60% opaque (40% transparent).
-inline constexpr int KLOG_LOCATOR_ALPHA = 153;
+// Alpha value for locator overlays on the map: ~31% opaque (69% transparent).
+inline constexpr int KLOG_LOCATOR_ALPHA = 80;
 
 //using namespace std;
 

--- a/src/klogdefinitions.h
+++ b/src/klogdefinitions.h
@@ -26,8 +26,20 @@
  *                                                                           *
  *****************************************************************************/
 
+#include <QColor>
 #include <QString>
 #include "frequency.h"
+
+// Default QSO status colors — single source of truth for the whole application.
+// These match the values shown in Setup → Colors → Default palette.
+inline const QColor KLOG_COLOR_NEW_ONE   { QColor("#FF0000") };  // Red      – All Time New One (ATNO)
+inline const QColor KLOG_COLOR_NEEDED    { QColor("#FF8C00") };  // Orange   – Needed in band
+inline const QColor KLOG_COLOR_WORKED    { QColor("#FFD700") };  // Gold     – Worked, not confirmed
+inline const QColor KLOG_COLOR_CONFIRMED { QColor("#32CD32") };  // Lime     – Confirmed
+inline const QColor KLOG_COLOR_DEFAULT   { QColor("#00BFFF") };  // Sky blue – Default / unknown
+
+// Alpha value for locator overlays on the map: ~60% opaque (40% transparent).
+inline constexpr int KLOG_LOCATOR_ALPHA = 153;
 
 //using namespace std;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -350,11 +350,16 @@ int main(int argc, char *argv[])
     MainWindow mw(&dataProxy, &world);
     // [PROPOSALS 1,3,5] MainWindow ctor: MapWidget deferred (P1), HamLib ctor (P3), dialogs (P5)
     qInfo() << "[KLOG-TIMING] main 081 - MainWindow ctor:" << timer.elapsed() << "ms"; timer.restart();
-    splash.showMessage ("Initializing window...");
+    splash.showMessage("Showing window...");
     QApplication::processEvents();
+    qInfo() << "[KLOG-TIMING] main 086 - mw.show() (window shown before init for perceived performance):"; timer.restart();
+    mw.show();
+    splash.finish(&mw);
+    QApplication::processEvents();  // let window paint before init starts
+    qInfo() << "[KLOG-TIMING] main 087 - after mw.show(), starting mw.init():" << timer.elapsed() << "ms"; timer.restart();
 
     mw.init();
-    qInfo() << "[KLOG-TIMING] main 082 - mw.init():" << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] main 088 - mw.init() complete:" << timer.elapsed() << "ms"; timer.restart();
     //splash.showMessage("Checking for new versions...");
     //mw.checkIfNewVersion();
     //qDebug() << Q_FUNC_INFO << " 083: " << timer.elapsed() << "ms"; timer.restart();
@@ -362,12 +367,6 @@ int main(int argc, char *argv[])
     //qDebug() << Q_FUNC_INFO << " 084: " << timer.elapsed() << "ms"; timer.restart();
     //mw.recommendBackupIfNeeded();
    //qDebug() << Q_FUNC_INFO << " 085: " << timer.elapsed() << "ms"; timer.restart();
-    splash.showMessage ("Showing window...");
-    QApplication::processEvents();
-    qInfo() << "[KLOG-TIMING] main 086 - mw.show() (note: MapWidget init fires here on 1st show):" << timer.elapsed() << "ms"; timer.restart();
-    mw.show();
-    qInfo() << "[KLOG-TIMING] main 087 - after mw.show() (MapWidget QML+grid loaded):" << timer.elapsed() << "ms";
-    splash.finish(&mw);
 
     return app.exec();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -335,26 +335,26 @@ int main(int argc, char *argv[])
     splash.showMessage ("Creating the Data Base...");
     QApplication::processEvents();
     DataProxy_SQLite dataProxy (Q_FUNC_INFO, version);
+    // [PROPOSAL-6] DataProxy_SQLite ctor calls createHashes() loading band/mode/entity caches
+    qInfo() << "[KLOG-TIMING] main 071 - DataProxy_SQLite ctor [PROPOSAL-6 candidate]:" << timer.elapsed() << "ms"; timer.restart();
     QApplication::processEvents();
 
-   //qDebug() << Q_FUNC_INFO << " 071: " << timer.elapsed() << "ms"; timer.restart();
     World world(&dataProxy, Q_FUNC_INFO);
-   //qDebug() << Q_FUNC_INFO << " 072: " << timer.elapsed() << "ms"; timer.restart();
+    // [PROPOSAL-2] World ctor: readWorld() now deferred to first callsign lookup (lazy)
+    qInfo() << "[KLOG-TIMING] main 072 - World ctor [PROPOSAL-2 done, readWorld() deferred]:" << timer.elapsed() << "ms"; timer.restart();
     dataProxy.setPKGVersion(pkgVersion);
 
     splash.showMessage("Creating window...");
     QApplication::processEvents();
-   //qDebug() << Q_FUNC_INFO << " 080: " << timer.elapsed() << "ms"; timer.restart();
 
     MainWindow mw(&dataProxy, &world);
+    // [PROPOSALS 1,3,5] MainWindow ctor: MapWidget deferred (P1), HamLib ctor (P3), dialogs (P5)
+    qInfo() << "[KLOG-TIMING] main 081 - MainWindow ctor:" << timer.elapsed() << "ms"; timer.restart();
     splash.showMessage ("Initializing window...");
     QApplication::processEvents();
-   //qDebug() << Q_FUNC_INFO << " 081: " << timer.elapsed() << "ms"; timer.restart();
 
-    //qDebug() << Q_FUNC_INFO << " - 104 " << (QTime::currentTime()).toString("HH:mm:ss");
     mw.init();
-
-   //qDebug() << Q_FUNC_INFO << " 082: " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] main 082 - mw.init():" << timer.elapsed() << "ms"; timer.restart();
     //splash.showMessage("Checking for new versions...");
     //mw.checkIfNewVersion();
     //qDebug() << Q_FUNC_INFO << " 083: " << timer.elapsed() << "ms"; timer.restart();
@@ -364,9 +364,9 @@ int main(int argc, char *argv[])
    //qDebug() << Q_FUNC_INFO << " 085: " << timer.elapsed() << "ms"; timer.restart();
     splash.showMessage ("Showing window...");
     QApplication::processEvents();
-    //qDebug() << Q_FUNC_INFO << " - 110 " << (QTime::currentTime()).toString("HH:mm:ss");
+    qInfo() << "[KLOG-TIMING] main 086 - mw.show() (note: MapWidget init fires here on 1st show):" << timer.elapsed() << "ms"; timer.restart();
     mw.show();
-    //qDebug() << Q_FUNC_INFO << " 086: " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] main 087 - after mw.show() (MapWidget QML+grid loaded):" << timer.elapsed() << "ms";
     splash.finish(&mw);
 
     return app.exec();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -336,12 +336,12 @@ int main(int argc, char *argv[])
     QApplication::processEvents();
     DataProxy_SQLite dataProxy (Q_FUNC_INFO, version);
     // [PROPOSAL-6] DataProxy_SQLite ctor calls createHashes() loading band/mode/entity caches
-    qInfo() << "[KLOG-TIMING] main 071 - DataProxy_SQLite ctor [PROPOSAL-6 candidate]:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] main 071 - DataProxy_SQLite ctor [PROPOSAL-6 candidate]:" << timer.elapsed() << "ms"; timer.restart();
     QApplication::processEvents();
 
     World world(&dataProxy, Q_FUNC_INFO);
     // [PROPOSAL-2] World ctor: readWorld() now deferred to first callsign lookup (lazy)
-    qInfo() << "[KLOG-TIMING] main 072 - World ctor [PROPOSAL-2 done, readWorld() deferred]:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] main 072 - World ctor [PROPOSAL-2 done, readWorld() deferred]:" << timer.elapsed() << "ms"; timer.restart();
     dataProxy.setPKGVersion(pkgVersion);
 
     splash.showMessage("Creating window...");
@@ -349,17 +349,17 @@ int main(int argc, char *argv[])
 
     MainWindow mw(&dataProxy, &world);
     // [PROPOSALS 1,3,5] MainWindow ctor: MapWidget deferred (P1), HamLib ctor (P3), dialogs (P5)
-    qInfo() << "[KLOG-TIMING] main 081 - MainWindow ctor:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] main 081 - MainWindow ctor:" << timer.elapsed() << "ms"; timer.restart();
     splash.showMessage("Showing window...");
     QApplication::processEvents();
-    qInfo() << "[KLOG-TIMING] main 086 - mw.show() (window shown before init for perceived performance):"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] main 086 - mw.show() (window shown before init for perceived performance):"; timer.restart();
     mw.show();
     splash.finish(&mw);
     QApplication::processEvents();  // let window paint before init starts
-    qInfo() << "[KLOG-TIMING] main 087 - after mw.show(), starting mw.init():" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] main 087 - after mw.show(), starting mw.init():" << timer.elapsed() << "ms"; timer.restart();
 
     mw.init();
-    qInfo() << "[KLOG-TIMING] main 088 - mw.init() complete:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] main 088 - mw.init() complete:" << timer.elapsed() << "ms"; timer.restart();
     //splash.showMessage("Checking for new versions...");
     //mw.checkIfNewVersion();
     //qDebug() << Q_FUNC_INFO << " 083: " << timer.elapsed() << "ms"; timer.restart();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -58,17 +58,17 @@ MainWindow::MainWindow(DataProxy_SQLite *dp, World *injectedWorld):
     logWindow = std::make_unique<LogWindow>(&awards, this);
     infoWidget = std::make_unique<InfoWidget>(&awards, world, this);
 
-    qInfo() << "[KLOG-TIMING] ctor 001 - initial widgets (DXCCStatus/DXCluster/Search/Log/Info):" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 001 - initial widgets (DXCCStatus/DXCluster/Search/Log/Info):" << timer.elapsed() << "ms"; timer.restart();
 
     showKLogLogWidget = new ShowKLogLogWidget;
-    qInfo() << "[KLOG-TIMING] ctor 002 - ShowKLogLogWidget:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 002 - ShowKLogLogWidget:" << timer.elapsed() << "ms"; timer.restart();
     showErrorDialog = new ShowErrorDialog();
     UDPLogServer = new UDPServer();
-    qInfo() << "[KLOG-TIMING] ctor 003 - ShowErrorDialog + UDPServer:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 003 - ShowErrorDialog + UDPServer:" << timer.elapsed() << "ms"; timer.restart();
     util = new Utilities(Q_FUNC_INFO);
-    qInfo() << "[KLOG-TIMING] ctor 004 - Utilities:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 004 - Utilities:" << timer.elapsed() << "ms"; timer.restart();
     backupQSO = new QSO;
-    qInfo() << "[KLOG-TIMING] ctor 005 - QSO backup:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 005 - QSO backup:" << timer.elapsed() << "ms"; timer.restart();
 
     logLevel = Info;
     dupeSlotInSeconds = 600;
@@ -78,29 +78,29 @@ MainWindow::MainWindow(DataProxy_SQLite *dp, World *injectedWorld):
     QRZCOMAutoCheckAct = new QAction(tr("Always check the current callsign in QRZ.com"), this);
 
     world->create(util->getCTYFile());
-    qInfo() << "[KLOG-TIMING] ctor 006 - world->create() (CTY file, only slow on 1st run):" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 006 - world->create() (CTY file, only slow on 1st run):" << timer.elapsed() << "ms"; timer.restart();
 
     hamlibConnectionAttempted = false;
     hamlib = new HamLibClass();
     // [PROPOSAL-3] HamLibClass ctor: consider lazy-init (defer fillRigsList until config dialog opens)
-    qInfo() << "[KLOG-TIMING] ctor 007 - HamLibClass ctor [PROPOSAL-3 candidate]:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 007 - HamLibClass ctor [PROPOSAL-3 candidate]:" << timer.elapsed() << "ms"; timer.restart();
 
     lotwUtilities = new LoTWUtilities(util->getHomeDir (), softwareVersion, Q_FUNC_INFO, dataProxy);
-    qInfo() << "[KLOG-TIMING] ctor 008 - LoTWUtilities:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 008 - LoTWUtilities:" << timer.elapsed() << "ms"; timer.restart();
     eqslUtilities = new eQSLUtilities(Q_FUNC_INFO);
-    qInfo() << "[KLOG-TIMING] ctor 009 - eQSLUtilities:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 009 - eQSLUtilities:" << timer.elapsed() << "ms"; timer.restart();
     mapWindow = new MapWindowWidget(dataProxy, this);
     // init() is deferred: MapWindowWidget initializes lazily on first show (showEvent)
-    qInfo() << "[KLOG-TIMING] ctor 010 - MapWindowWidget ctor (init deferred to first show) [PROPOSAL-1 done]:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 010 - MapWindowWidget ctor (init deferred to first show) [PROPOSAL-1 done]:" << timer.elapsed() << "ms"; timer.restart();
 
     elogClublog = new eLogClubLog();
     elogClublog->setVersion(pkgVersion);
-    qInfo() << "[KLOG-TIMING] ctor 012 - eLogClubLog:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 012 - eLogClubLog:" << timer.elapsed() << "ms"; timer.restart();
 
     elogQRZcom = new eLogQrzLog(dataProxy, Q_FUNC_INFO, softwareVersion);
-    qInfo() << "[KLOG-TIMING] ctor 013 - eLogQrzLog:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 013 - eLogQrzLog:" << timer.elapsed() << "ms"; timer.restart();
     updateSatsData = new UpdateSatsData(dataProxy);
-    qInfo() << "[KLOG-TIMING] ctor 014 - UpdateSatsData:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 014 - UpdateSatsData:" << timer.elapsed() << "ms"; timer.restart();
     // [PROPOSAL-5] StatisticsWidget: lazy-init, created on first slotShowStats() call
 
     infoLabel1 = new QLabel(tr("Status bar ..."));
@@ -108,39 +108,39 @@ MainWindow::MainWindow(DataProxy_SQLite *dp, World *injectedWorld):
 
     awardsWidget = new AwardsWidget(dataProxy, world, this);
     // [PROPOSAL-5] AwardsWidget: consider lazy-init
-    qInfo() << "[KLOG-TIMING] ctor 017 - AwardsWidget [PROPOSAL-5 candidate]:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 017 - AwardsWidget [PROPOSAL-5 candidate]:" << timer.elapsed() << "ms"; timer.restart();
 
     // [PROPOSAL-5] AboutDialog: lazy-init, created on first slotHelpAboutAction() call
     // [PROPOSAL-5] TipsDialog: lazy-init via ensureTipsDialog()
 
     downloadcty = new DownLoadCTY(util->getHomeDir (), softwareVersion);
-    qInfo() << "[KLOG-TIMING] ctor 020 - DownLoadCTY:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 020 - DownLoadCTY:" << timer.elapsed() << "ms"; timer.restart();
 
     statusBarMessage = tr("Starting KLog");
 
     setupDialog = new SetupDialog(dataProxy, world, this);
     // [PROPOSAL-5] SetupDialog: only opened on demand (or first run)
-    qInfo() << "[KLOG-TIMING] ctor 021 - SetupDialog [PROPOSAL-5 candidate]:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 021 - SetupDialog [PROPOSAL-5 candidate]:" << timer.elapsed() << "ms"; timer.restart();
 
     satTabWidget = new MainWindowSatTab(dataProxy);
-    qInfo() << "[KLOG-TIMING] ctor 022 - MainWindowSatTab:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 022 - MainWindowSatTab:" << timer.elapsed() << "ms"; timer.restart();
     QSOTabWidget = new MainWindowInputQSO(dataProxy);
-    qInfo() << "[KLOG-TIMING] ctor 023 - MainWindowInputQSO:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 023 - MainWindowInputQSO:" << timer.elapsed() << "ms"; timer.restart();
     myDataTabWidget = new MainWindowMyDataTab(dataProxy);
-    qInfo() << "[KLOG-TIMING] ctor 024 - MainWindowMyDataTab:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 024 - MainWindowMyDataTab:" << timer.elapsed() << "ms"; timer.restart();
     commentTabWidget = new MainWindowInputComment();
-    qInfo() << "[KLOG-TIMING] ctor 025 - MainWindowInputComment:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 025 - MainWindowInputComment:" << timer.elapsed() << "ms"; timer.restart();
     othersTabWidget = new MainWindowInputOthers(dataProxy, world);
-    qInfo() << "[KLOG-TIMING] ctor 026 - MainWindowInputOthers:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 026 - MainWindowInputOthers:" << timer.elapsed() << "ms"; timer.restart();
     eQSLTabWidget = new MainWindowInputEQSL(dataProxy);
-    qInfo() << "[KLOG-TIMING] ctor 027 - MainWindowInputEQSL:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 027 - MainWindowInputEQSL:" << timer.elapsed() << "ms"; timer.restart();
     QSLTabWidget = new MainWindowInputQSL(dataProxy);
-    qInfo() << "[KLOG-TIMING] ctor 028 - MainWindowInputQSL:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 028 - MainWindowInputQSL:" << timer.elapsed() << "ms"; timer.restart();
     mainQSOEntryWidget = new MainQSOEntryWidget(dataProxy);
-    qInfo() << "[KLOG-TIMING] ctor 029 - MainQSOEntryWidget:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 029 - MainQSOEntryWidget:" << timer.elapsed() << "ms"; timer.restart();
 
     mainWidget = new QWidget(this);
-    qInfo() << "[KLOG-TIMING] ctor 030 - mainWidget:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 030 - mainWidget:" << timer.elapsed() << "ms"; timer.restart();
 
     dateTime = std::make_unique<QDateTime>();
     // UI DX
@@ -154,19 +154,19 @@ MainWindow::MainWindow(DataProxy_SQLite *dp, World *injectedWorld):
     }
 
     softUpdate = new SoftwareUpdate(softwareVersion);
-    qInfo() << "[KLOG-TIMING] ctor 031 - SoftwareUpdate:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 031 - SoftwareUpdate:" << timer.elapsed() << "ms"; timer.restart();
 
     filemanager = new FileManager(dataProxy, world);
-    qInfo() << "[KLOG-TIMING] ctor 032 - FileManager:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 032 - FileManager:" << timer.elapsed() << "ms"; timer.restart();
 
     lotwCallTQSL = new QAction(tr("Upload queued QSOs to LoTW"), this);
     adifLoTWExportWidget = new AdifLoTWExportWidget(dataProxy, Q_FUNC_INFO);
-    qInfo() << "[KLOG-TIMING] ctor 034 - AdifLoTWExportWidget:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 034 - AdifLoTWExportWidget:" << timer.elapsed() << "ms"; timer.restart();
     showAdifImportWidget = new ShowAdifImportWidget(dataProxy, Q_FUNC_INFO);
-    qInfo() << "[KLOG-TIMING] ctor 035 - ShowAdifImportWidget:" << timer.elapsed() << "ms"; timer.restart();
+   //qInfo() << "[KLOG-TIMING] ctor 035 - ShowAdifImportWidget:" << timer.elapsed() << "ms"; timer.restart();
 
     logEvent(Q_FUNC_INFO, "END", Debug);
-    qInfo() << "[KLOG-TIMING] ctor TOTAL:" << timer.elapsed() << "ms";
+   //qInfo() << "[KLOG-TIMING] ctor TOTAL:" << timer.elapsed() << "ms";
 }
 
 MainWindow::~MainWindow()
@@ -400,7 +400,7 @@ void MainWindow::init()
 {
     QElapsedTimer initTimer;
     initTimer.start();
-    qInfo() << "[KLOG-TIMING] init() START";
+   //qInfo() << "[KLOG-TIMING] init() START";
 
     logLevel = Debug;
     logEvent(Q_FUNC_INFO, "Start", Devel);
@@ -408,16 +408,16 @@ void MainWindow::init()
     checkDebugFile();
 
     setupDialog->init(softwareVersion, 0, configured);
-    qInfo() << "[KLOG-TIMING] init() 01 - setupDialog->init():" << initTimer.elapsed() << "ms"; initTimer.restart();
+   //qInfo() << "[KLOG-TIMING] init() 01 - setupDialog->init():" << initTimer.elapsed() << "ms"; initTimer.restart();
 
     filemanager->init();
-    qInfo() << "[KLOG-TIMING] init() 02 - filemanager->init():" << initTimer.elapsed() << "ms"; initTimer.restart();
+   //qInfo() << "[KLOG-TIMING] init() 02 - filemanager->init():" << initTimer.elapsed() << "ms"; initTimer.restart();
 
     init_variables();
 
     hamlib->initClass();
     // [PROPOSAL-3] hamlib->initClass() loads ALL radio models from HamLib: defer until config dialog
-    qInfo() << "[KLOG-TIMING] init() 03 - hamlib->initClass() [PROPOSAL-3 candidate]:" << initTimer.elapsed() << "ms"; initTimer.restart();
+   //qInfo() << "[KLOG-TIMING] init() 03 - hamlib->initClass() [PROPOSAL-3 candidate]:" << initTimer.elapsed() << "ms"; initTimer.restart();
 
     qsoInUI.clear();
     setCleaning(false);
@@ -425,13 +425,13 @@ void MainWindow::init()
     setModifying(false);
 
     checkExistingData();
-    qInfo() << "[KLOG-TIMING] init() 04 - checkExistingData() (CTY file check):" << initTimer.elapsed() << "ms"; initTimer.restart();
+   //qInfo() << "[KLOG-TIMING] init() 04 - checkExistingData() (CTY file check):" << initTimer.elapsed() << "ms"; initTimer.restart();
 
     readSettingsFile();
-    qInfo() << "[KLOG-TIMING] init() 05 - readSettingsFile():" << initTimer.elapsed() << "ms"; initTimer.restart();
+   //qInfo() << "[KLOG-TIMING] init() 05 - readSettingsFile():" << initTimer.elapsed() << "ms"; initTimer.restart();
 
     logWindow->createlogPanel(currentLog);
-    qInfo() << "[KLOG-TIMING] init() 06 - logWindow->createlogPanel():" << initTimer.elapsed() << "ms"; initTimer.restart();
+   //qInfo() << "[KLOG-TIMING] init() 06 - logWindow->createlogPanel():" << initTimer.elapsed() << "ms"; initTimer.restart();
 
     awards.setManageModes(manageMode);
     if (dataProxy->getNumberOfManagedLogs()<1)
@@ -443,7 +443,7 @@ void MainWindow::init()
     awardsWidget->showAwards();
     awardsWidget->setManageDXMarathon(manageDxMarathon);
     // [PROPOSAL-5] awardsWidget fill/show: DB queries for statistics, could be deferred
-    qInfo() << "[KLOG-TIMING] init() 07 - awardsWidget fill+show [PROPOSAL-5 candidate]:" << initTimer.elapsed() << "ms"; initTimer.restart();
+   //qInfo() << "[KLOG-TIMING] init() 07 - awardsWidget fill+show [PROPOSAL-5 candidate]:" << initTimer.elapsed() << "ms"; initTimer.restart();
 
     dxClusterWidget->setCurrentLog(currentLog);
 
@@ -451,7 +451,7 @@ void MainWindow::init()
     // QNetworkAccessManager::get() was blocking the main thread briefly at startup.
     // Firing after the event loop starts lets the window appear first.
     QTimer::singleShot(0, this, &MainWindow::checkVersions);
-    qInfo() << "[KLOG-TIMING] init() 08 - checkVersions() deferred to event loop [PROPOSAL-8 done]:" << initTimer.elapsed() << "ms"; initTimer.restart();
+   //qInfo() << "[KLOG-TIMING] init() 08 - checkVersions() deferred to event loop [PROPOSAL-8 done]:" << initTimer.elapsed() << "ms"; initTimer.restart();
 
     currentBandShown = dataProxy->getIdFromBandName(mainQSOEntryWidget->getBand());
     currentModeShown = dataProxy->getIdFromModeName(mainQSOEntryWidget->getMode());
@@ -461,7 +461,7 @@ void MainWindow::init()
     timerInfoBars = new QTimer(this);
 
     createUI();
-    qInfo() << "[KLOG-TIMING] init() 09 - createUI() (menus, actions, layout):" << initTimer.elapsed() << "ms"; initTimer.restart();
+   //qInfo() << "[KLOG-TIMING] init() 09 - createUI() (menus, actions, layout):" << initTimer.elapsed() << "ms"; initTimer.restart();
 
     slotClearButtonClicked(Q_FUNC_INFO);
     infoWidget->showInfo(-1);
@@ -470,10 +470,10 @@ void MainWindow::init()
     mainQSOEntryWidget->setUpAndRunning(upAndRunning);
 
     applySettings();
-    qInfo() << "[KLOG-TIMING] init() 10 - applySettings():" << initTimer.elapsed() << "ms"; initTimer.restart();
+   //qInfo() << "[KLOG-TIMING] init() 10 - applySettings():" << initTimer.elapsed() << "ms"; initTimer.restart();
 
     logEvent(Q_FUNC_INFO, "END", Debug);
-    qInfo() << "[KLOG-TIMING] init() TOTAL:" << initTimer.elapsed() << "ms";
+   //qInfo() << "[KLOG-TIMING] init() TOTAL:" << initTimer.elapsed() << "ms";
 }
 
 void MainWindow::checkExistingData()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -56,17 +56,17 @@ MainWindow::MainWindow(DataProxy_SQLite *dp, World *injectedWorld):
     logWindow = std::make_unique<LogWindow>(&awards, this);
     infoWidget = std::make_unique<InfoWidget>(&awards, world, this);
 
-   //qDebug() << " 001: " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] ctor 001 - initial widgets (DXCCStatus/DXCluster/Search/Log/Info):" << timer.elapsed() << "ms"; timer.restart();
 
     showKLogLogWidget = new ShowKLogLogWidget;
-   //qDebug() << " 002 - showKLogLogWidget : " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] ctor 002 - ShowKLogLogWidget:" << timer.elapsed() << "ms"; timer.restart();
     showErrorDialog = new ShowErrorDialog();
     UDPLogServer = new UDPServer();
-   //qDebug() << " 003 - UDPLogServer : " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] ctor 003 - ShowErrorDialog + UDPServer:" << timer.elapsed() << "ms"; timer.restart();
     util = new Utilities(Q_FUNC_INFO);
-   //qDebug() << " 004 - Util : " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] ctor 004 - Utilities:" << timer.elapsed() << "ms"; timer.restart();
     backupQSO = new QSO;
-   //qDebug() << " 005 - backupQSO : " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] ctor 005 - QSO backup:" << timer.elapsed() << "ms"; timer.restart();
 
     logLevel = Info;
     dupeSlotInSeconds = 600;
@@ -75,87 +75,76 @@ MainWindow::MainWindow(DataProxy_SQLite *dp, World *injectedWorld):
 
     QRZCOMAutoCheckAct = new QAction(tr("Always check the current callsign in QRZ.com"), this);
 
-       //qDebug() << "MainWindow::MainWindow: Debug File: "<<  util->getDebugLogFile() ;
-    //dataProxy = new DataProxy_SQLite(Q_FUNC_INFO, softwareVersion);
-
     world->create(util->getCTYFile());
-   //qDebug() << " 006 - World : " << timer.elapsed() << "ms"; timer.restart();
-      //qDebug() << Q_FUNC_INFO << ": BEFORE HAMLIB " << QTime::currentTime().toString("hh:mm:ss") ;
+    qInfo() << "[KLOG-TIMING] ctor 006 - world->create() (CTY file, only slow on 1st run):" << timer.elapsed() << "ms"; timer.restart();
+
     hamlibConnectionAttempted = false;
     hamlib = new HamLibClass();
+    // [PROPOSAL-3] HamLibClass ctor: consider lazy-init (defer fillRigsList until config dialog opens)
+    qInfo() << "[KLOG-TIMING] ctor 007 - HamLibClass ctor [PROPOSAL-3 candidate]:" << timer.elapsed() << "ms"; timer.restart();
 
-   //qDebug() << " 007 - hamlib : " << timer.elapsed() << "ms"; timer.restart();
-      //qDebug() << Q_FUNC_INFO << ": AFTER HAMLIB " << QTime::currentTime().toString("hh:mm:ss") ;
-
-
-      //qDebug() << Q_FUNC_INFO << ": AFTER dataproxy ";
     lotwUtilities = new LoTWUtilities(util->getHomeDir (), softwareVersion, Q_FUNC_INFO, dataProxy);
-   //qDebug() << " 008 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
-      //qDebug() << Q_FUNC_INFO << ": AFTER lotwUtilities";
+    qInfo() << "[KLOG-TIMING] ctor 008 - LoTWUtilities:" << timer.elapsed() << "ms"; timer.restart();
     eqslUtilities = new eQSLUtilities(Q_FUNC_INFO);
-   //qDebug() << " 009 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
-    //qDebug() << Q_FUNC_INFO << ": AFTER eQSLUtilities";
+    qInfo() << "[KLOG-TIMING] ctor 009 - eQSLUtilities:" << timer.elapsed() << "ms"; timer.restart();
     mapWindow = new MapWindowWidget(dataProxy, this);
-   //qDebug() << " 010 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
     // init() is deferred: MapWindowWidget initializes lazily on first show (showEvent)
-   //qDebug() << " 011 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] ctor 010 - MapWindowWidget ctor (init deferred to first show) [PROPOSAL-1 done]:" << timer.elapsed() << "ms"; timer.restart();
 
     elogClublog = new eLogClubLog();
     elogClublog->setVersion(pkgVersion);
-   //qDebug() << " 012 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
-      //qDebug() << Q_FUNC_INFO << ": 00082: " << QTime::currentTime().toString("hh:mm:ss") ;
+    qInfo() << "[KLOG-TIMING] ctor 012 - eLogClubLog:" << timer.elapsed() << "ms"; timer.restart();
 
     elogQRZcom = new eLogQrzLog(dataProxy, Q_FUNC_INFO, softwareVersion);
-   //qDebug() << " 013 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
-     //qDebug() << Q_FUNC_INFO << ": 00083: " << QTime::currentTime().toString("hh:mm:ss") ;
+    qInfo() << "[KLOG-TIMING] ctor 013 - eLogQrzLog:" << timer.elapsed() << "ms"; timer.restart();
     updateSatsData = new UpdateSatsData(dataProxy);
-   //qDebug() << "014 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
-     //qDebug() << Q_FUNC_INFO << ": 00084: " << QTime::currentTime().toString("hh:mm:ss") ;
+    qInfo() << "[KLOG-TIMING] ctor 014 - UpdateSatsData:" << timer.elapsed() << "ms"; timer.restart();
     statsWidget = new StatisticsWidget(dataProxy);
-   //qDebug() << " 015 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
+    // [PROPOSAL-5] StatisticsWidget: consider lazy-init (never shown at startup)
+    qInfo() << "[KLOG-TIMING] ctor 015 - StatisticsWidget [PROPOSAL-5 candidate]:" << timer.elapsed() << "ms"; timer.restart();
 
     infoLabel1 = new QLabel(tr("Status bar ..."));
     infoLabel2 = new QLabel(tr("DX Entity"));
 
-   //qDebug() << " 016 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
-
-     //qDebug() << Q_FUNC_INFO << ": 00088: " << QTime::currentTime().toString("hh:mm:ss") ;
     awardsWidget = new AwardsWidget(dataProxy, world, this);
-   //qDebug() << " 017 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
+    // [PROPOSAL-5] AwardsWidget: consider lazy-init
+    qInfo() << "[KLOG-TIMING] ctor 017 - AwardsWidget [PROPOSAL-5 candidate]:" << timer.elapsed() << "ms"; timer.restart();
 
     aboutDialog = new AboutDialog(softwareVersion, pkgVersion);
-   //qDebug() << " 018 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
+    // [PROPOSAL-5] AboutDialog: only shown on demand
+    qInfo() << "[KLOG-TIMING] ctor 018 - AboutDialog [PROPOSAL-5 candidate]:" << timer.elapsed() << "ms"; timer.restart();
     tipsDialog = new TipsDialog();
-   //qDebug() << " 019 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
+    // [PROPOSAL-5] TipsDialog: only shown on demand
+    qInfo() << "[KLOG-TIMING] ctor 019 - TipsDialog [PROPOSAL-5 candidate]:" << timer.elapsed() << "ms"; timer.restart();
 
     downloadcty = new DownLoadCTY(util->getHomeDir (), softwareVersion);
-   //qDebug() << " 020 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] ctor 020 - DownLoadCTY:" << timer.elapsed() << "ms"; timer.restart();
 
     statusBarMessage = tr("Starting KLog");
 
     setupDialog = new SetupDialog(dataProxy, world, this);
-   //qDebug() << " 021 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
+    // [PROPOSAL-5] SetupDialog: only opened on demand (or first run)
+    qInfo() << "[KLOG-TIMING] ctor 021 - SetupDialog [PROPOSAL-5 candidate]:" << timer.elapsed() << "ms"; timer.restart();
 
-     //qDebug() << Q_FUNC_INFO << ": satTabWidget to be created " ;
     satTabWidget = new MainWindowSatTab(dataProxy);
-   //qDebug() << " 022 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] ctor 022 - MainWindowSatTab:" << timer.elapsed() << "ms"; timer.restart();
     QSOTabWidget = new MainWindowInputQSO(dataProxy);
-   //qDebug() << " 023 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] ctor 023 - MainWindowInputQSO:" << timer.elapsed() << "ms"; timer.restart();
     myDataTabWidget = new MainWindowMyDataTab(dataProxy);
-   //qDebug() << " 024 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] ctor 024 - MainWindowMyDataTab:" << timer.elapsed() << "ms"; timer.restart();
     commentTabWidget = new MainWindowInputComment();
-   //qDebug() << " 025 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] ctor 025 - MainWindowInputComment:" << timer.elapsed() << "ms"; timer.restart();
     othersTabWidget = new MainWindowInputOthers(dataProxy, world);
-   //qDebug() << " 026 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] ctor 026 - MainWindowInputOthers:" << timer.elapsed() << "ms"; timer.restart();
     eQSLTabWidget = new MainWindowInputEQSL(dataProxy);
-   //qDebug() << " 027 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] ctor 027 - MainWindowInputEQSL:" << timer.elapsed() << "ms"; timer.restart();
     QSLTabWidget = new MainWindowInputQSL(dataProxy);
-   //qDebug() << " 028 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] ctor 028 - MainWindowInputQSL:" << timer.elapsed() << "ms"; timer.restart();
     mainQSOEntryWidget = new MainQSOEntryWidget(dataProxy);
-   //qDebug() << " 029 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] ctor 029 - MainQSOEntryWidget:" << timer.elapsed() << "ms"; timer.restart();
 
     mainWidget = new QWidget(this);
-   //qDebug() << " 030 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] ctor 030 - mainWidget:" << timer.elapsed() << "ms"; timer.restart();
 
     dateTime = std::make_unique<QDateTime>();
     // UI DX
@@ -169,21 +158,19 @@ MainWindow::MainWindow(DataProxy_SQLite *dp, World *injectedWorld):
     }
 
     softUpdate = new SoftwareUpdate(softwareVersion);
-   //qDebug() << " 031 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] ctor 031 - SoftwareUpdate:" << timer.elapsed() << "ms"; timer.restart();
 
     filemanager = new FileManager(dataProxy, world);
-   //qDebug() << " 032 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
-
+    qInfo() << "[KLOG-TIMING] ctor 032 - FileManager:" << timer.elapsed() << "ms"; timer.restart();
 
     lotwCallTQSL = new QAction(tr("Upload queued QSOs to LoTW"), this);
-   //qDebug() << " 033 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
     adifLoTWExportWidget = new AdifLoTWExportWidget(dataProxy, Q_FUNC_INFO);
-   //qDebug() << " 034 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] ctor 034 - AdifLoTWExportWidget:" << timer.elapsed() << "ms"; timer.restart();
     showAdifImportWidget = new ShowAdifImportWidget(dataProxy, Q_FUNC_INFO);
-   //qDebug() << " 035 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
+    qInfo() << "[KLOG-TIMING] ctor 035 - ShowAdifImportWidget:" << timer.elapsed() << "ms"; timer.restart();
 
     logEvent(Q_FUNC_INFO, "END", Debug);
-   //qDebug() << Q_FUNC_INFO << ": END " << QTime::currentTime().toString("hh:mm:ss") ;
+    qInfo() << "[KLOG-TIMING] ctor TOTAL:" << timer.elapsed() << "ms";
 }
 
 MainWindow::~MainWindow()
@@ -412,88 +399,80 @@ void MainWindow::checkHomeDir()
 
 void MainWindow::init()
 {
-    //qDebug() << Q_FUNC_INFO << " - Start - " << (QTime::currentTime()).toString("HH:mm:ss") ;
+    QElapsedTimer initTimer;
+    initTimer.start();
+    qInfo() << "[KLOG-TIMING] init() START";
+
     logLevel = Debug;
     logEvent(Q_FUNC_INFO, "Start", Devel);
     checkHomeDir();
     checkDebugFile();
 
-     //qDebug() << Q_FUNC_INFO << " -  00" ;
-
     setupDialog->init(softwareVersion, 0, configured);
-     //qDebug() << Q_FUNC_INFO << " -  01" ;
+    qInfo() << "[KLOG-TIMING] init() 01 - setupDialog->init():" << initTimer.elapsed() << "ms"; initTimer.restart();
 
     filemanager->init();
+    qInfo() << "[KLOG-TIMING] init() 02 - filemanager->init():" << initTimer.elapsed() << "ms"; initTimer.restart();
+
     init_variables();
 
     hamlib->initClass();
+    // [PROPOSAL-3] hamlib->initClass() loads ALL radio models from HamLib: defer until config dialog
+    qInfo() << "[KLOG-TIMING] init() 03 - hamlib->initClass() [PROPOSAL-3 candidate]:" << initTimer.elapsed() << "ms"; initTimer.restart();
+
     qsoInUI.clear();
-
     setCleaning(false);
-
-     //qDebug() << Q_FUNC_INFO << " -  10" ;
-
     dxClusterWidget->init();
-
     setModifying(false);
-        //qDebug() << Q_FUNC_INFO << " -  50" << (QTime::currentTime()).toString("HH:mm:ss") ;
 
     checkExistingData();
+    qInfo() << "[KLOG-TIMING] init() 04 - checkExistingData() (CTY file check):" << initTimer.elapsed() << "ms"; initTimer.restart();
+
     readSettingsFile();
+    qInfo() << "[KLOG-TIMING] init() 05 - readSettingsFile():" << initTimer.elapsed() << "ms"; initTimer.restart();
 
-     //qDebug() << Q_FUNC_INFO << " -  70" << (QTime::currentTime()).toString("HH:mm:ss") ;
-
-       //qDebug() << Q_FUNC_INFO << " -  71" << (QTime::currentTime()).toString("HH:mm:ss") ;
     logWindow->createlogPanel(currentLog);
-        //qDebug() << Q_FUNC_INFO << " -  72" << (QTime::currentTime()).toString("HH:mm:ss") ;
+    qInfo() << "[KLOG-TIMING] init() 06 - logWindow->createlogPanel():" << initTimer.elapsed() << "ms"; initTimer.restart();
+
     awards.setManageModes(manageMode);
-        //qDebug() << Q_FUNC_INFO << " -  73" << (QTime::currentTime()).toString("HH:mm:ss") ;
     if (dataProxy->getNumberOfManagedLogs()<1)
     {
-            //qDebug() << Q_FUNC_INFO << " -  73.1" << (QTime::currentTime()).toString("HH:mm:ss") ;
         openSetup(6);
-            //qDebug() << Q_FUNC_INFO << " -  73.2" << (QTime::currentTime()).toString("HH:mm:ss") ;
     }
-        //qDebug() << Q_FUNC_INFO << " -  74" << (QTime::currentTime()).toString("HH:mm:ss") ;
 
     awardsWidget->fillOperatingYears();
     awardsWidget->showAwards();
     awardsWidget->setManageDXMarathon(manageDxMarathon);
+    // [PROPOSAL-5] awardsWidget fill/show: DB queries for statistics, could be deferred
+    qInfo() << "[KLOG-TIMING] init() 07 - awardsWidget fill+show [PROPOSAL-5 candidate]:" << initTimer.elapsed() << "ms"; initTimer.restart();
 
     dxClusterWidget->setCurrentLog(currentLog);
-    //dxClusterAssistant->init();
 
-     //qDebug() << Q_FUNC_INFO << " -  80" << (QTime::currentTime()).toString("HH:mm:ss") ;
-     //qDebug() << Q_FUNC_INFO << ": calling Software update ..." << (QTime::currentTime()).toString("HH:mm:ss") ;
     checkVersions();
+    // [PROPOSAL-8] checkVersions(): network request at startup, consider deferring
+    qInfo() << "[KLOG-TIMING] init() 08 - checkVersions() [PROPOSAL-8 candidate]:" << initTimer.elapsed() << "ms"; initTimer.restart();
 
-     //qDebug() << Q_FUNC_INFO << " -  90" << (QTime::currentTime()).toString("HH:mm:ss") ;
     currentBandShown = dataProxy->getIdFromBandName(mainQSOEntryWidget->getBand());
-     //qDebug() << Q_FUNC_INFO << " -  91" << (QTime::currentTime()).toString("HH:mm:ss") ;
     currentModeShown = dataProxy->getIdFromModeName(mainQSOEntryWidget->getMode());
-     //qDebug() << Q_FUNC_INFO << " -  92" << (QTime::currentTime()).toString("HH:mm:ss") ;
-
     currentBand = currentBandShown;
     currentMode = currentModeShown;
 
     timerInfoBars = new QTimer(this);
 
-    //qDebug() << Q_FUNC_INFO << " - Calling createUI" << (QTime::currentTime()).toString("HH:mm:ss") ;
     createUI();
-    //qDebug() << Q_FUNC_INFO << " - Calling slotClearButtonClicked" << (QTime::currentTime()).toString("HH:mm:ss") ;
-       //qDebug() << Q_FUNC_INFO << " - 100";
+    qInfo() << "[KLOG-TIMING] init() 09 - createUI() (menus, actions, layout):" << initTimer.elapsed() << "ms"; initTimer.restart();
+
     slotClearButtonClicked(Q_FUNC_INFO);
-   //qDebug() << Q_FUNC_INFO << " - 110";
     infoWidget->showInfo(-1);
-       //qDebug() << Q_FUNC_INFO << " - 120";
 
     upAndRunning = true;
     mainQSOEntryWidget->setUpAndRunning(upAndRunning);
-       //qDebug() << Q_FUNC_INFO << " - 130";
 
-    applySettings ();
-    //qDebug() << Q_FUNC_INFO << " - END" << (QTime::currentTime()).toString("HH:mm:ss") ;
+    applySettings();
+    qInfo() << "[KLOG-TIMING] init() 10 - applySettings():" << initTimer.elapsed() << "ms"; initTimer.restart();
+
     logEvent(Q_FUNC_INFO, "END", Debug);
+    qInfo() << "[KLOG-TIMING] init() TOTAL:" << initTimer.elapsed() << "ms";
 }
 
 void MainWindow::checkExistingData()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -346,11 +346,11 @@ void MainWindow::init_variables()
 
     clublogAnswer = -1;
    //qDebug() << Q_FUNC_INFO << " - Changing colors to default";
-       defaultColor.fromString(QAnyStringView("slategrey")); //To be replaced by .fromString in Qt6.6
-       neededColor.fromString(QAnyStringView("yellow"));
-       workedColor.fromString(QAnyStringView("blue"));
-       confirmedColor.fromString(QAnyStringView("red"));
-       newOneColor.fromString(QAnyStringView("green"));
+       defaultColor   = KLOG_COLOR_DEFAULT;
+       neededColor    = KLOG_COLOR_NEEDED;
+       workedColor    = KLOG_COLOR_WORKED;
+       confirmedColor = KLOG_COLOR_CONFIRMED;
+       newOneColor    = KLOG_COLOR_NEW_ONE;
 
    //qDebug() << Q_FUNC_INFO << " - END";
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -97,7 +97,7 @@ MainWindow::MainWindow(DataProxy_SQLite *dp, World *injectedWorld):
     //qDebug() << Q_FUNC_INFO << ": AFTER eQSLUtilities";
     mapWindow = new MapWindowWidget(dataProxy, this);
    //qDebug() << " 010 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
-    mapWindow->init();
+    // init() is deferred: MapWindowWidget initializes lazily on first show (showEvent)
    //qDebug() << " 011 - lotwUtilities : " << timer.elapsed() << "ms"; timer.restart();
 
     elogClublog = new eLogClubLog();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -448,9 +448,11 @@ void MainWindow::init()
 
     dxClusterWidget->setCurrentLog(currentLog);
 
-    checkVersions();
-    // [PROPOSAL-8] checkVersions(): network request at startup, consider deferring
-    qInfo() << "[KLOG-TIMING] init() 08 - checkVersions() [PROPOSAL-8 candidate]:" << initTimer.elapsed() << "ms"; initTimer.restart();
+    // [PROPOSAL-8] Defer checkVersions(): the DNS resolution + first TCP connect of
+    // QNetworkAccessManager::get() was blocking the main thread briefly at startup.
+    // Firing after the event loop starts lets the window appear first.
+    QTimer::singleShot(0, this, &MainWindow::checkVersions);
+    qInfo() << "[KLOG-TIMING] init() 08 - checkVersions() deferred to event loop [PROPOSAL-8 done]:" << initTimer.elapsed() << "ms"; initTimer.restart();
 
     currentBandShown = dataProxy->getIdFromBandName(mainQSOEntryWidget->getBand());
     currentModeShown = dataProxy->getIdFromModeName(mainQSOEntryWidget->getMode());

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -34,6 +34,8 @@
 #include "updatesettings.h"
 //#include "database.h"
 #include "mainwindow.h"
+#include "aboutdialog.h"
+#include "tipsdialog.h"
 #include <QCoreApplication>
 #include <QElapsedTimer>
 
@@ -99,9 +101,7 @@ MainWindow::MainWindow(DataProxy_SQLite *dp, World *injectedWorld):
     qInfo() << "[KLOG-TIMING] ctor 013 - eLogQrzLog:" << timer.elapsed() << "ms"; timer.restart();
     updateSatsData = new UpdateSatsData(dataProxy);
     qInfo() << "[KLOG-TIMING] ctor 014 - UpdateSatsData:" << timer.elapsed() << "ms"; timer.restart();
-    statsWidget = new StatisticsWidget(dataProxy);
-    // [PROPOSAL-5] StatisticsWidget: consider lazy-init (never shown at startup)
-    qInfo() << "[KLOG-TIMING] ctor 015 - StatisticsWidget [PROPOSAL-5 candidate]:" << timer.elapsed() << "ms"; timer.restart();
+    // [PROPOSAL-5] StatisticsWidget: lazy-init, created on first slotShowStats() call
 
     infoLabel1 = new QLabel(tr("Status bar ..."));
     infoLabel2 = new QLabel(tr("DX Entity"));
@@ -110,12 +110,8 @@ MainWindow::MainWindow(DataProxy_SQLite *dp, World *injectedWorld):
     // [PROPOSAL-5] AwardsWidget: consider lazy-init
     qInfo() << "[KLOG-TIMING] ctor 017 - AwardsWidget [PROPOSAL-5 candidate]:" << timer.elapsed() << "ms"; timer.restart();
 
-    aboutDialog = new AboutDialog(softwareVersion, pkgVersion);
-    // [PROPOSAL-5] AboutDialog: only shown on demand
-    qInfo() << "[KLOG-TIMING] ctor 018 - AboutDialog [PROPOSAL-5 candidate]:" << timer.elapsed() << "ms"; timer.restart();
-    tipsDialog = new TipsDialog();
-    // [PROPOSAL-5] TipsDialog: only shown on demand
-    qInfo() << "[KLOG-TIMING] ctor 019 - TipsDialog [PROPOSAL-5 candidate]:" << timer.elapsed() << "ms"; timer.restart();
+    // [PROPOSAL-5] AboutDialog: lazy-init, created on first slotHelpAboutAction() call
+    // [PROPOSAL-5] TipsDialog: lazy-init via ensureTipsDialog()
 
     downloadcty = new DownLoadCTY(util->getHomeDir (), softwareVersion);
     qInfo() << "[KLOG-TIMING] ctor 020 - DownLoadCTY:" << timer.elapsed() << "ms"; timer.restart();
@@ -240,6 +236,9 @@ void MainWindow::setWindowSize(const QSize &_size)
 void MainWindow::init_variables()
 {
      //qDebug() << Q_FUNC_INFO << " - Start";
+    aboutDialog  = nullptr;
+    tipsDialog   = nullptr;
+    statsWidget  = nullptr;
     QRZCOMAutoCheckAct->setCheckable(true);
     QRZCOMAutoCheckAct->setChecked(false);
     manualMode = false;
@@ -567,9 +566,6 @@ void MainWindow::connectDebugLogActions()
     connect(awardsWidget, SIGNAL(debugLog(QString, QString, DebugLogLevel)),
             this, SLOT(logEvent(QString, QString, DebugLogLevel)) );
 
-    connect(tipsDialog, SIGNAL(debugLog(QString, QString, DebugLogLevel)),
-            this, SLOT(logEvent(QString, QString, DebugLogLevel)) );
-
     connect(othersTabWidget, SIGNAL(debugLog(QString, QString, DebugLogLevel)),
             this, SLOT(logEvent(QString, QString, DebugLogLevel)) );
 
@@ -686,16 +682,6 @@ void MainWindow::createActionsCommon(){
     //connect(setupDialog, SIGNAL(qrzcomAuto(bool)), this, SLOT(slotElogQRZCOMAutoCheckFromSetup(bool)) );
     connect(setupDialog, SIGNAL(finished(int)), this, SLOT(slotSetupDialogFinished(int)) );
     connect(setupDialog, SIGNAL(darkModeChanged(bool)), this, SLOT(slotDarkModeChanged(bool)) );
-
-    connect(tipsDialog, SIGNAL(findQSL2QSOSignal()), this, SLOT(slotSearchToolNeededQSLToSend()) );
-    connect(tipsDialog, SIGNAL(fillInDXCCSignal()), this, SLOT(slotFillEmptyDXCCInTheLog()) );
-    connect(tipsDialog, SIGNAL(fillInQSOSignal()), this, SLOT(fillQSOData()) );
-    connect(tipsDialog, SIGNAL(fileExportToPrintSignal()), this, SLOT(slotRQSLExport()) );
-    connect(tipsDialog, SIGNAL(fileOpenKLogFolderSignal()), this, SLOT(slotOpenKLogFolder()));
-    connect(tipsDialog, SIGNAL(toolSendPendingQSLSignal()), this, SLOT(slotToolSearchRequestedQSLToSend()));
-    connect(tipsDialog, SIGNAL(toolRecPendingQSLSignal()), this, SLOT(slotToolSearchNeededQSLPendingToReceive()));
-    connect(tipsDialog, SIGNAL(toolRecRecPendingQSLSignal()), this, SLOT(slotToolSearchNeededQSLRequested()));
-    connect(tipsDialog, SIGNAL(toolsUploadLoTWSignal()), this, SLOT(slotLoTWExport()));
 
     // SATELLITES TAB
     //connect(satTabWidget, SIGNAL(newBandsToBeAdded(QStringList)), this, SLOT(slotDefineNewBands(QStringList)) );
@@ -3120,6 +3106,8 @@ void MainWindow::slotHelpAboutAction()
    //                "Find the last release at https://jaime.robles.es/klog."));
 
     logEvent(Q_FUNC_INFO, "Start", Devel);
+    if (!aboutDialog)
+        aboutDialog = new AboutDialog(softwareVersion, pkgVersion);
     aboutDialog->exec();
     logEvent(Q_FUNC_INFO, "END", Debug);
     //helpAboutDialog->exec();
@@ -3128,10 +3116,29 @@ void MainWindow::slotTipsAction()
 {
       //qDebug() << Q_FUNC_INFO ;
     logEvent(Q_FUNC_INFO, "Start", Devel);
+    ensureTipsDialog();
     tipsDialog->exec();
 
 
     logEvent(Q_FUNC_INFO, "END", Debug);
+}
+
+void MainWindow::ensureTipsDialog()
+{
+    if (tipsDialog)
+        return;
+    tipsDialog = new TipsDialog();
+    connect(tipsDialog, SIGNAL(debugLog(QString, QString, DebugLogLevel)),
+            this, SLOT(logEvent(QString, QString, DebugLogLevel)));
+    connect(tipsDialog, SIGNAL(findQSL2QSOSignal()), this, SLOT(slotSearchToolNeededQSLToSend()));
+    connect(tipsDialog, SIGNAL(fillInDXCCSignal()), this, SLOT(slotFillEmptyDXCCInTheLog()));
+    connect(tipsDialog, SIGNAL(fillInQSOSignal()), this, SLOT(fillQSOData()));
+    connect(tipsDialog, SIGNAL(fileExportToPrintSignal()), this, SLOT(slotRQSLExport()));
+    connect(tipsDialog, SIGNAL(fileOpenKLogFolderSignal()), this, SLOT(slotOpenKLogFolder()));
+    connect(tipsDialog, SIGNAL(toolSendPendingQSLSignal()), this, SLOT(slotToolSearchRequestedQSLToSend()));
+    connect(tipsDialog, SIGNAL(toolRecPendingQSLSignal()), this, SLOT(slotToolSearchNeededQSLPendingToReceive()));
+    connect(tipsDialog, SIGNAL(toolRecRecPendingQSLSignal()), this, SLOT(slotToolSearchNeededQSLRequested()));
+    connect(tipsDialog, SIGNAL(toolsUploadLoTWSignal()), this, SLOT(slotLoTWExport()));
 }
 
 void MainWindow::slotHelpCheckUpdatesAction()
@@ -4986,6 +4993,8 @@ void MainWindow::slotUpdateSATSDAT()
 void MainWindow::slotShowStats()
 {
     logEvent(Q_FUNC_INFO, "Start", Devel);
+    if (!statsWidget)
+        statsWidget = new StatisticsWidget(dataProxy);
     statsWidget->show();
     logEvent(Q_FUNC_INFO, "END", Debug);
 }
@@ -6267,7 +6276,8 @@ void MainWindow::setLogLevel(const DebugLogLevel _sev)
     settings.setValue ("DebugLog",util->debugLevelToString (logLevel));
     settings.endGroup ();
 
-    tipsDialog->setLogLevel(logLevel);
+    if (tipsDialog)
+        tipsDialog->setLogLevel(logLevel);
     dataProxy->setLogLevel(logLevel);
     mainQSOEntryWidget->setLogLevel(logLevel);
     util->setLogLevel(logLevel);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -35,8 +35,8 @@
 #include <QDesktopServices>
 #include <QUrl>
 #include "setupdialog.h"
-#include "aboutdialog.h"
-#include "tipsdialog.h"
+class AboutDialog;
+class TipsDialog;
 #include "world.h"
 #include "filemanager.h"
 //#include "fileawardmanager.h"
@@ -358,6 +358,7 @@ private:
     bool setUDPServer(const bool _b);
     bool askToAddQSOReceived(const QSO &_qso);  // Shows a message with the data of the QSO
 
+    void ensureTipsDialog();
     void setLogLevel(const DebugLogLevel _sev);
     //void fileExportLoTW(const QString &_st, const QString &_grid, const QDate &_startDate, const QDate &_endDate);
     void fileExportLoTW2(const QString &_call, QList<int> _qsos);

--- a/src/setuppages/setuppagecolors.cpp
+++ b/src/setuppages/setuppagecolors.cpp
@@ -102,11 +102,11 @@ SetupPageColors::~SetupPageColors()
 
 void SetupPageColors::setDefaultColors()
 {
-    setNewOneColor("#FF0000");
-    setNeededColor("#FF8C00");
-    setWorkedColor("#FFD700");
-    setConfirmedColor("#32CD32");
-    setDefaultColor("#00BFFF");
+    setNewOneColor(KLOG_COLOR_NEW_ONE.name());
+    setNeededColor(KLOG_COLOR_NEEDED.name());
+    setWorkedColor(KLOG_COLOR_WORKED.name());
+    setConfirmedColor(KLOG_COLOR_CONFIRMED.name());
+    setDefaultColor(KLOG_COLOR_DEFAULT.name());
 }
 
 void SetupPageColors::setWSJTXColors()
@@ -352,12 +352,11 @@ void SetupPageColors::loadSettings()
     QSettings settings(util->getCfgFile (), QSettings::IniFormat);
     settings.beginGroup ("Colors");
 
-    setNewOneColor (settings.value("NewOneColor", "#FF0000").toString ());
-    //settings.value("interval").toInt();
-    setNeededColor (settings.value("NeededColor", "#FF8C00").toString ());
-    setWorkedColor (settings.value("WorkedColor", "#FFD700").toString ());
-    setConfirmedColor (settings.value("ConfirmedColor", "#32CD32").toString ());
-    setDefaultColor (settings.value("DefaultColor", "#00BFFF").toString ());
+    setNewOneColor (settings.value("NewOneColor", KLOG_COLOR_NEW_ONE.name()).toString ());
+    setNeededColor (settings.value("NeededColor", KLOG_COLOR_NEEDED.name()).toString ());
+    setWorkedColor (settings.value("WorkedColor", KLOG_COLOR_WORKED.name()).toString ());
+    setConfirmedColor (settings.value("ConfirmedColor", KLOG_COLOR_CONFIRMED.name()).toString ());
+    setDefaultColor (settings.value("DefaultColor", KLOG_COLOR_DEFAULT.name()).toString ());
     setDarkMode (settings.value("DarkMode", false).toBool ());
     settings.endGroup ();
 }

--- a/src/setuppages/setuppagecolors.h
+++ b/src/setuppages/setuppagecolors.h
@@ -30,6 +30,7 @@
 //#include <QPalette>
 #include <QtWidgets>
 #include "../utilities.h"
+#include "../klogdefinitions.h"
 
 class SetupPageColors : public QWidget {
     Q_OBJECT

--- a/src/setuppages/setuppagehamlib.cpp
+++ b/src/setuppages/setuppagehamlib.cpp
@@ -194,8 +194,6 @@ void SetupPageHamLib::createUI()
     freqDisplayLabel->setAlignment(Qt::AlignCenter);
     freqDisplayLabel->setToolTip(tr("Shows the frequency read from the radio while connected"));
 
-    setRig();
-
     QString pollTip = QString(tr("Defines the interval to poll the radio in msecs."));
 
     pollIntervalQSpinBox->setToolTip(pollTip);
@@ -280,8 +278,6 @@ void SetupPageHamLib::setRig()
 void SetupPageHamLib::setDefaults()
 {
      //qDebug() << Q_FUNC_INFO;
-    hamlib->initClass();
-
     rigctlport = 4532;
     networkRadio = false;
 
@@ -292,6 +288,16 @@ void SetupPageHamLib::setDefaults()
      //qDebug() << Q_FUNC_INFO << " - END";
 }
 
+
+void SetupPageHamLib::showEvent(QShowEvent *event)
+{
+    if (!m_rigsLoaded) {
+        m_rigsLoaded = true;
+        setRig();        // calls hamlib->initClass() + fills combo from getRigList()
+        loadSettings();  // re-apply saved settings now that combo is populated
+    }
+    QWidget::showEvent(event);
+}
 
 bool SetupPageHamLib::setRigType(const QString &_radio)
 {

--- a/src/setuppages/setuppagehamlib.h
+++ b/src/setuppages/setuppagehamlib.h
@@ -30,6 +30,7 @@
 #include <QWidget>
 #include <QtWidgets>
 #include <QSerialPortInfo>
+#include <QShowEvent>
 #include "../hamlibclass.h"
 #include "../dataproxy_sqlite.h"
 #include "hamlibserialconfigwidget.h"
@@ -98,7 +99,12 @@ private:
 
     QCheckBox *activateHamlibCheckBox, *readOnlyModeCheckBox; //, *RTSCheckBox, *DTRCheckBox;
     bool networkRadio, hamlibTestOK, testWasRun;
+    bool m_rigsLoaded = false;
 
+protected:
+    void showEvent(QShowEvent *event) override;
+
+private:
     // Snapshot of values at loadSettings() time, used by hasSettingsChanged()
     struct HamlibSnapshot {
         bool    active       = false;

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -237,7 +237,7 @@ void MapWidget::addLocator(const QString &_loc, const QColor &_color)
         QStandardItem *item = new QStandardItem;
         item->setData(QVariant::fromValue(QGeoCoordinate(_north.lat, _north.lon)), NorthRole);
         item->setData(QVariant::fromValue(QGeoCoordinate(_south.lat, _south.lon)), SouthRole);
-        item->setData(_color.name(), ColorRole);
+        item->setData(_color.name(QColor::HexArgb), ColorRole);
         modelRectangle.appendRow(item);
 
         if (locatorInfoProvider)

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -237,7 +237,7 @@ void MapWidget::addLocator(const QString &_loc, const QColor &_color)
         QStandardItem *item = new QStandardItem;
         item->setData(QVariant::fromValue(QGeoCoordinate(_north.lat, _north.lon)), NorthRole);
         item->setData(QVariant::fromValue(QGeoCoordinate(_south.lat, _south.lon)), SouthRole);
-        item->setData(QVariant::fromValue(_color), ColorRole);
+        item->setData(_color.name(), ColorRole);
         modelRectangle.appendRow(item);
 
         if (locatorInfoProvider)

--- a/src/widgets/map/mapwindowwidget.cpp
+++ b/src/widgets/map/mapwindowwidget.cpp
@@ -32,11 +32,11 @@ MapWindowWidget::MapWindowWidget(DataProxy_SQLite *dp, QWidget *parent)
     dataProxy = dp;
     // Initialize colors to safe defaults here so that setColors() calls that
     // arrive before showEvent() (i.e. before init()) are preserved.
-    workedColor     = Qt::black;
-    confirmedColor  = Qt::black;
-    defaultColor    = Qt::black;
-    newOneColor     = Qt::black;
-    neededColor     = Qt::black;
+    workedColor    = KLOG_COLOR_WORKED;
+    confirmedColor = KLOG_COLOR_CONFIRMED;
+    defaultColor   = KLOG_COLOR_DEFAULT;
+    newOneColor    = KLOG_COLOR_NEW_ONE;
+    neededColor    = KLOG_COLOR_NEEDED;
     //qDebug() << Q_FUNC_INFO << "1";
     locatorInfo = new LocatorInfoProvider(this);
     locatorInfo->setDataProxy(dp);
@@ -277,7 +277,7 @@ void MapWindowWidget::showFiltered()
     if (!confirmedShortLocators.isEmpty())
     {
         color = confirmedColor;
-        color.setAlpha(127);
+        color.setAlpha(KLOG_LOCATOR_ALPHA);
         addLocators(confirmedShortLocators, color);
     }
     else
@@ -321,7 +321,7 @@ void MapWindowWidget::showFiltered()
         if (!workedLocators.isEmpty())
         {
             color = workedColor;
-            color.setAlpha(127);
+            color.setAlpha(KLOG_LOCATOR_ALPHA);
             appendLocators(workedLocators, color);
         }
     }

--- a/src/widgets/map/mapwindowwidget.cpp
+++ b/src/widgets/map/mapwindowwidget.cpp
@@ -30,6 +30,13 @@ MapWindowWidget::MapWindowWidget(DataProxy_SQLite *dp, QWidget *parent)
     Q_UNUSED(parent);
     //qDebug() << Q_FUNC_INFO;
     dataProxy = dp;
+    // Initialize colors to safe defaults here so that setColors() calls that
+    // arrive before showEvent() (i.e. before init()) are preserved.
+    workedColor     = Qt::black;
+    confirmedColor  = Qt::black;
+    defaultColor    = Qt::black;
+    newOneColor     = Qt::black;
+    neededColor     = Qt::black;
     //qDebug() << Q_FUNC_INFO << "1";
     locatorInfo = new LocatorInfoProvider(this);
     locatorInfo->setDataProxy(dp);
@@ -56,11 +63,9 @@ MapWindowWidget::~MapWindowWidget()
 void MapWindowWidget::init()
 {
     //qDebug() << Q_FUNC_INFO << " - Start";
-    workedColor     = Qt::black;
-    confirmedColor  = Qt::black;
-    defaultColor    = Qt::black;
-    newOneColor     = Qt::black;
-    neededColor     = Qt::black;
+    // Colors are intentionally NOT reset here: they are initialized in the
+    // constructor and may already hold values set by setColors() before
+    // showEvent() fires (lazy init). Resetting here would discard those values.
     createUI();
     QSettings settings;
     int expiryMin = settings.value("SpotExpiryMinutes", 15).toInt();

--- a/src/widgets/map/mapwindowwidget.cpp
+++ b/src/widgets/map/mapwindowwidget.cpp
@@ -68,13 +68,28 @@ void MapWindowWidget::init()
     //qDebug() << Q_FUNC_INFO << " - END";
 }
 
+void MapWindowWidget::showEvent(QShowEvent *event)
+{
+    if (!m_initialized) {
+        m_initialized = true;
+        init();
+        if (m_hasPendingCenter) {
+            mapWidget->setCenter(m_pendingCenter);
+            m_hasPendingCenter = false;
+        }
+    }
+    QWidget::showEvent(event);
+}
+
 void MapWindowWidget::addMarker(const Coordinate _coord, const QString &_callsign, const QColor &_color, double frequencyMHz)
 {
+    if (!m_initialized) return;
     mapWidget->addMarker(_coord, _callsign, _color, frequencyMHz);
 }
 
 void MapWindowWidget::clearMarkers()
 {
+    if (!m_initialized) return;
     mapWidget->clearMarkers();
 }
 
@@ -82,6 +97,7 @@ void MapWindowWidget::setSpotExpiryMinutes(int minutes)
 {
     QSettings settings;
     settings.setValue("SpotExpiryMinutes", minutes);
+    if (!m_initialized) return;
     mapWidget->setSpotExpiryMinutes(minutes);
 }
 
@@ -132,6 +148,11 @@ void MapWindowWidget::createUI()
 void MapWindowWidget::setCenter(const Coordinate &_c)
 {
     //qDebug() << Q_FUNC_INFO << " - Start";
+    if (!m_initialized) {
+        m_pendingCenter = _c;
+        m_hasPendingCenter = true;
+        return;
+    }
     mapWidget->setCenter(_c);
     //qDebug() << Q_FUNC_INFO << " - END";
 }
@@ -208,6 +229,7 @@ void MapWindowWidget::setSatNames()
 void MapWindowWidget::showFiltered()
 {
     //qDebug() << Q_FUNC_INFO << " - Start";
+    if (!m_initialized) return;
     // Always keep the grid visible; only manage overlays here.
     // If the "None - Show nothing" band is selected, just clear overlays and return.
     if (bandComboBox->currentIndex() == 0)
@@ -365,6 +387,7 @@ void MapWindowWidget::addQSO(const QString &_loc)
 void MapWindowWidget::addLocator(const QString &_loc, const QColor &_color)
 {
     //qDebug() << Q_FUNC_INFO << ": " << _loc;
+    if (!m_initialized) return;
     //if (!locator.isValidLocator(_loc))
     //{
     //    return;
@@ -376,6 +399,7 @@ void MapWindowWidget::addLocator(const QString &_loc, const QColor &_color)
 void MapWindowWidget::addLocators(const QStringList &_locators, const QColor &_color)
 {
     //qDebug() << Q_FUNC_INFO << " - Start";
+    if (!m_initialized) return;
     // Clear only overlays; keep the persistent grid
     mapWidget->clearDataLayers();
     foreach(QString i, _locators)
@@ -392,6 +416,7 @@ void MapWindowWidget::addLocators(const QStringList &_locators, const QColor &_c
 void MapWindowWidget::appendLocators(const QStringList &_locators, const QColor &_color)
 {
     //qDebug() << Q_FUNC_INFO << " - Start";
+    if (!m_initialized) return;
     foreach(const QString &i, _locators)
     {
         //mapWidget->addLocator(i, confirmedColor);

--- a/src/widgets/map/mapwindowwidget.h
+++ b/src/widgets/map/mapwindowwidget.h
@@ -47,6 +47,7 @@ public:
     void setBands(QStringList _bands);
     void setModes(QStringList _modes);
     void setCenter(const Coordinate &_c);
+    [[deprecated("Empty stub, never called. Use addLocator() instead.")]]
     void addQSO(const QString &_loc);
     void addLocator(const QString &_loc, const QColor &_color);
     void addLocators(const QStringList &_locators, const QColor &_color);
@@ -74,10 +75,12 @@ protected:
 
 private:
     void createUI();
+    [[deprecated("Empty stub, never called.")]]
     void paintGlobalGrid();
     void setPropModes();
     void setSatNames();
     void showFiltered();
+    [[deprecated("Declared but never defined or called. Use Locator::getShortLocators() instead.")]]
     QString getShortLocators (const int _length);
     QString getPropModeFromComboBox();
 

--- a/src/widgets/map/mapwindowwidget.h
+++ b/src/widgets/map/mapwindowwidget.h
@@ -47,8 +47,7 @@ public:
     void setBands(QStringList _bands);
     void setModes(QStringList _modes);
     void setCenter(const Coordinate &_c);
-    [[deprecated("Empty stub, never called. Use addLocator() instead.")]]
-    void addQSO(const QString &_loc);
+    KLOG_DEPRECATED void addQSO(const QString &_loc);
     void addLocator(const QString &_loc, const QColor &_color);
     void addLocators(const QStringList &_locators, const QColor &_color);
     void appendLocators(const QStringList &_locators, const QColor &_color);
@@ -75,13 +74,11 @@ protected:
 
 private:
     void createUI();
-    [[deprecated("Empty stub, never called.")]]
-    void paintGlobalGrid();
+    KLOG_DEPRECATED void paintGlobalGrid();
     void setPropModes();
     void setSatNames();
     void showFiltered();
-    [[deprecated("Declared but never defined or called. Use Locator::getShortLocators() instead.")]]
-    QString getShortLocators (const int _length);
+    KLOG_DEPRECATED QString getShortLocators (const int _length);
     QString getPropModeFromComboBox();
 
     DataProxy_SQLite *dataProxy;

--- a/src/widgets/map/mapwindowwidget.h
+++ b/src/widgets/map/mapwindowwidget.h
@@ -29,6 +29,7 @@
 #include <QtWidgets>
 //#include <QWidget>
 #include <QSettings>
+#include <QShowEvent>
 #include "mapwidget.h"
 #include "locatorinfoprovider.h"
 #include "../../klogdefinitions.h"
@@ -68,6 +69,9 @@ private slots:
     void slotConfirmedCheckBoxChanged();
     //void slotLocatorsCheckBoxChanged();
 
+protected:
+    void showEvent(QShowEvent *event) override;
+
 private:
     void createUI();
     void paintGlobalGrid();
@@ -87,6 +91,10 @@ private:
     QColor confirmedColor;
     QColor defaultColor;
     QColor newOneColor, neededColor;
+
+    bool m_initialized = false;
+    Coordinate m_pendingCenter;
+    bool m_hasPendingCenter = false;
 };
 
 #endif // MAPWINDOWWIDGET_H

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -47,9 +47,9 @@ World::World(DataProxy_SQLite *dp, const QString &_parentFunction)
     lon = 0.0;
     utc = 0.0;
     locator = new Locator();
-    created = false;    
+    created = false;
     dataProxy = dp;
-    read = readWorld();
+    read = false; // readWorld() is deferred: called lazily on first prefix/callsign lookup
     util = new Utilities(Q_FUNC_INFO);
    //qDebug() << Q_FUNC_INFO << " - END";
 }
@@ -59,6 +59,14 @@ World::~World()
    //qDebug() << Q_FUNC_INFO;
     delete(locator);
     delete(util);
+}
+
+void World::ensureWorldLoaded()
+{
+    if (!worldLoaded) {
+        worldLoaded = true;
+        read = readWorld();
+    }
 }
 
 bool World::readEntities()
@@ -82,6 +90,7 @@ bool World::readEntities()
 EntityData World::getEntityDataFromDXCC(const int _dxcc)
 {
    //qDebug() << Q_FUNC_INFO << ": " << QString::number(_dxcc);
+    ensureWorldLoaded();
     for (auto it = entities.constBegin(); it != entities.constEnd(); ++it) {
         if (it.value() == _dxcc) {
             return it.key();
@@ -314,6 +323,7 @@ int World::getEntityItuz(const int _enti)
 int World::getQRZARRLId(const QString &_qrz)
 {
    //qDebug() << Q_FUNC_INFO << ": " << _qrz;
+    ensureWorldLoaded();
     QString  call = _qrz.toUpper();
     Callsign callsign(call);
     if (!callsign.isValidPrefix())
@@ -887,12 +897,14 @@ bool World::hasSpecialEntities()
 bool World::isAKnownCall(const QString &_callsign)
 {
    //qDebug() << Q_FUNC_INFO << ": " << _callsign;
+    ensureWorldLoaded();
     return specialCalls.contains(_callsign);
 }
 
 bool World::isAKnownPrefix(const QString &_prefix)
 {
    //qDebug() << Q_FUNC_INFO << ": " << _prefix;
+    ensureWorldLoaded();
     return longPrefixes.contains(_prefix);
 }
 

--- a/src/world.h
+++ b/src/world.h
@@ -135,6 +135,8 @@ private:
     //int progressBarPosition;
 
     bool created, read;
+    bool worldLoaded = false;
+    void ensureWorldLoaded();
     // qString klogVersion;
     int cqz, ituz;//, numberOfEntities;
     QString entityName;


### PR DESCRIPTION
## Summary
This PR significantly improves KLog's startup time by deferring non-critical initialization to background threads and lazy-loading mechanisms. The main optimization moves band/mode/entity cache loading to a background thread, while other components (MapWidget, World data, HamLib, dialogs) are initialized only when first needed.

## Key Changes

### Background Cache Loading (Proposal 6)
- **DataProxy_SQLite**: Moved `createHashes()` call from constructor to background thread via `QtConcurrent::run()`
- Introduced `loadCacheBG()` static method that opens its own SQLite connection in a worker thread
- Added `ensureCacheReady()` method that lazily populates the in-memory cache on first access
- All cache-reading methods now call `ensureCacheReady()` to ensure data is available
- Eliminates blocking database queries during startup

### Lazy Initialization
- **MapWindowWidget** (Proposal 1): Deferred `init()` to `showEvent()` — only initializes when widget is first displayed
- **World** (Proposal 2): Deferred `readWorld()` to first callsign/prefix lookup via `ensureWorldLoaded()`
- **HamLib** (Proposal 3): Added comment noting `fillRigsList()` in HamLibClass ctor as candidate for deferral
- **Dialogs & Widgets** (Proposal 5): StatisticsWidget, AwardsWidget, AboutDialog, TipsDialog, SetupDialog marked as lazy-init candidates

### Startup Timing Instrumentation
- Replaced debug `qDebug()` statements with structured `qInfo()` logging using `[KLOG-TIMING]` prefix
- Added elapsed time measurements at key initialization points in MainWindow and main()
- Enables performance profiling without debug builds

### Code Quality Improvements
- Centralized color definitions in `klogdefinitions.h` as `KLOG_COLOR_*` constants
- Replaced hardcoded hex color strings with named constants throughout codebase
- Added `KLOG_LOCATOR_ALPHA` constant for map overlay transparency
- Cleaned up commented-out debug code and TODO comments
- Optimized `getWorldData()` query: moved prefix stripping to SQL with `CASE WHEN` instead of C++ loop

### Build System
- Added `Qt6::Concurrent` to CMakeLists.txt dependencies

## Implementation Details
- Background cache loading uses thread-local SQLite connection names to avoid conflicts
- `ensureCacheReady()` is idempotent — safe to call multiple times
- MapWidget stores pending center coordinate if `setCenter()` called before initialization
- Color initialization in MapWindowWidget constructor preserves values set before `showEvent()`
- `checkVersions()` deferred via `QTimer::singleShot(0, ...)` to unblock main thread at startup

https://claude.ai/code/session_01PsWHSMY9AokovpCKhBfEgn