### PR TITLE
Fix log view sort order reset after using settings dialog. Fixes issue #988

### DIFF
--- a/src/logwindow.cpp
+++ b/src/logwindow.cpp
@@ -265,6 +265,18 @@ void LogWindow::showColumn(const QString &_columnName)
 void LogWindow::refresh()
 {
   //qDebug() << Q_FUNC_INFO << " - Start";
+    // Re-apply the view's current sort indicator to the model before selecting.
+    // LogModel::setColumns() (called whenever columns are reconfigured, e.g. when
+    // the settings dialog is shown) resets the model's ORDER BY to "id ASC".
+    // If the log did not change, createlogPanel() is not re-run, so the sort is
+    // never restored — the next select() would return rows in the wrong order,
+    // placing newly saved QSOs at the bottom instead of the top.
+    // The header's sort indicator is not affected by setColumns(), so it always
+    // reflects the last sort the user (or createlogPanel) requested.
+    int sortSection = logView->horizontalHeader()->sortIndicatorSection();
+    if (sortSection >= 0)
+        logModel->setSort(sortSection, logView->horizontalHeader()->sortIndicatorOrder());
+
     if (!logModel->select())
     {
         //qDebug() << Q_FUNC_INFO << " - ERROR on select()";


### PR DESCRIPTION
LogModel::setColumns() always resets the model's ORDER BY to "id ASC" (line 228 of logmodel.cpp).  This is called via logWindow->setColumns() from loadSettings() every time the settings dialog is shown.  If the selected log did not change, createlogPanel() is skipped on dialog close, so the sort is never restored to the user-visible sort order. The next refresh() then runs select() with the wrong ORDER BY, placing newly saved QSOs at the bottom instead of the top.

Fix: re-apply the view header's sort indicator to the model at the start of refresh(), before calling select().  The header indicator is not touched by setColumns(), so it always reflects the correct order.