### PR TITLE
FreeDV UDP QSOLogged integration improvements

### DIFF
--- a/src/logwindow.cpp
+++ b/src/logwindow.cpp
@@ -265,6 +265,7 @@ void LogWindow::showColumn(const QString &_columnName)
 void LogWindow::refresh()
 {
   //qDebug() << Q_FUNC_INFO << " - Start";
+    logModel->setSort(1, Qt::DescendingOrder);
     if (!logModel->select())
     {
         //qDebug() << Q_FUNC_INFO << " - ERROR on select()";

--- a/src/mainqsoentrywidget.cpp
+++ b/src/mainqsoentrywidget.cpp
@@ -50,6 +50,7 @@ MainQSOEntryWidget::MainQSOEntryWidget(DataProxy_SQLite *dp, QWidget *parent) : 
     timer = new QTimer(this);
     util = new Utilities(Q_FUNC_INFO);
     realTime = true;
+    freezeTime = false;
     duplicatedQSOSlotInSecs = 600;
     delayInputTimer = new QTimer;
     logLevel = None;
@@ -908,6 +909,11 @@ void MainQSOEntryWidget::setRealTime(const bool _realTime)
     logEvent (Q_FUNC_INFO, "END", Debug);
 }
 
+void MainQSOEntryWidget::setFreezeTime(const bool _freeze)
+{
+    freezeTime = _freeze;
+}
+
 void MainQSOEntryWidget::setManualMode(const bool _manualMode)
 {
     logEvent (Q_FUNC_INFO, "Start", Debug);
@@ -966,7 +972,7 @@ void MainQSOEntryWidget::slotUpdateTime()
 {
     logEvent (Q_FUNC_INFO, "Start", Debug);
     //qDebug()<< Q_FUNC_INFO;
-    if ( (!modify) && (realtimeCheckBox->isChecked())  )
+    if ( (!modify) && (realtimeCheckBox->isChecked()) && (!freezeTime) )
     {
        //qDebug()<< Q_FUNC_INFO << ":  Real Time & update";
         setDateAndTimeInternally();

--- a/src/mainqsoentrywidget.cpp
+++ b/src/mainqsoentrywidget.cpp
@@ -446,6 +446,7 @@ void MainQSOEntryWidget::clear()
 {
     logEvent (Q_FUNC_INFO, "Start", Debug);
    //qDebug() << Q_FUNC_INFO;
+    freezeTime = false;
     fillingQSO = false;
     setModify(false);
     //OKButton->setText(tr("&Add"));

--- a/src/mainqsoentrywidget.h
+++ b/src/mainqsoentrywidget.h
@@ -74,6 +74,7 @@ public:
 
     void setRealTime(const bool _realTime);
     bool getRealTime();
+    void setFreezeTime(const bool _freeze);  // Pause/resume the auto-update clock without touching the realtime checkbox
     void setManualMode(const bool _manualMode);
     bool getManualMode();
 
@@ -174,6 +175,8 @@ private:
     DebugLogLevel logLevel;
     bool modifyingBands;
     bool fillingQSO;        // TRUE just when a QSO is being written in the UI from a qsoToEdit
+    bool freezeTime;        // TRUE while a UDP QSO is pending — suppresses slotUpdateTime so the
+                            // UDP-supplied date/time is shown without touching the realtime checkbox
 };
 
 #endif // MAINQSOENTRYWIDGET_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5695,6 +5695,11 @@ void MainWindow::slotShowQSOsFromDXCCWidget(QList<int> _qsos)
     if (!q.getDateTimeOn().isValid())
         q.setDateTimeOn(udpArrivalTime);
 
+    // The QSOLogged packet carries frequency but not band name.  Derive the
+    // band from the frequency so that isComplete() passes and addQSO() succeeds.
+    if (q.getBand().isEmpty())
+        q.setBand(dataProxy->getBandNameFromFreq(q.getFreqTX()));
+
     // Supplement fields that _qso lacked but the form may now have
     // (e.g. name filled in by QRZ.com after the form was populated above).
     if (q.getName().isEmpty())

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5638,121 +5638,94 @@ void MainWindow::slotShowQSOsFromDXCCWidget(QList<int> _qsos)
     logEvent(Q_FUNC_INFO, "END", Debug);
 }
 
-    void MainWindow::slotQSOReceived(const QSO &_qso)
+void MainWindow::slotQSOReceived(const QSO &_qso)
 {
-    //qDebug() <<  Q_FUNC_INFO << " - Start";
-    //logEvent(Q_FUNC_INFO, "Start", Devel);
-
-    // Latch UDP-sourced fields immediately so that cleanQRZCOMreceivedDataFromUI()
-    // can restore them if a QRZ.com lookup fires before or after the form is populated.
     udpLoggedCall    = _qso.getCall();
     udpLoggedName    = _qso.getName();
     udpLoggedLocator = _qso.getGridSquare();
 
-    // FreeDV does not populate time_on in its QSOLogged packet, so capture the
-    // packet arrival time now as the best available QSO timestamp.
     const QDateTime udpArrivalTime = _qso.getDateTimeOn().isValid()
                                      ? _qso.getDateTimeOn()
                                      : QDateTime::currentDateTimeUtc();
 
     if (!wsjtxAutoLog)
-    {
-        // Don't overwrite a QSO the user is currently editing or a manual-mode session.
-        if (modify || manualMode)
-            return;
+        populateFormFromUDPQso(_qso, udpArrivalTime);
+    else
+        autoLogUDPQso(_qso, udpArrivalTime);
 
-        // Manual-add mode: freeze the clock at packet arrival time and populate the
-        // entry form so the user can review and edit before clicking Add.
-        // The clock unfreezes when the form is cleared (Add or Clear).
-        // Do NOT call addQSO here — the normal Add button path saves the QSO.
-        mainQSOEntryWidget->setFreezeTime(true);
-        mainQSOEntryWidget->setDateTime(udpArrivalTime);
+    logEvent(Q_FUNC_INFO, "END", Debug);
+}
 
-        // Populate form fields.  QRZ only overwrites empty fields (see
-        // slotElogQRZCOMFoundData), so setting name/comment/RST here preserves
-        // values that FreeDV already provided against QRZ.com overwriting them.
-        if (!_qso.getComment().isEmpty())
-            commentTabWidget->setData(_qso.getComment());
-        if (!_qso.getName().isEmpty())
-            QSOTabWidget->setName(_qso.getName());
-        if (!_qso.getRSTTX().isEmpty())
-            QSOTabWidget->setRSTTX(_qso.getRSTTX());
-        if (!_qso.getRSTRX().isEmpty())
-            QSOTabWidget->setRSTRX(_qso.getRSTRX());
-
-        mainQSOEntryWidget->setQRZ(_qso.getCall());
-        const QString udpBand = dataProxy->getBandNameFromFreq(_qso.getFreqTX());
-        if (!udpBand.isEmpty())
-            mainQSOEntryWidget->setBand(udpBand);
-        const QString udpMode = _qso.getSubmode().isEmpty() ? _qso.getMode() : _qso.getSubmode();
-        if (!udpMode.isEmpty())
-            mainQSOEntryWidget->setMode(udpMode);
+void MainWindow::populateFormFromUDPQso(const QSO &_qso, const QDateTime &_arrivalTime)
+{
+    // Don't overwrite a QSO the user is currently editing or a manual-mode session.
+    if (modify || manualMode)
         return;
-    }
 
-    // Auto-log path: save directly to DB without touching the form.
-   //qDebug() << Q_FUNC_INFO << "010";
+    // Freeze the clock at packet arrival time and populate the entry form so the
+    // user can review and edit before clicking Add.  The clock unfreezes when the
+    // form is cleared (Add or Clear).
+    mainQSOEntryWidget->setFreezeTime(true);
+    mainQSOEntryWidget->setDateTime(_arrivalTime);
+
+    // QRZ only overwrites empty fields (see slotElogQRZCOMFoundData), so setting
+    // name/comment/RST here preserves values that FreeDV already provided.
+    if (!_qso.getComment().isEmpty())
+        commentTabWidget->setData(_qso.getComment());
+    if (!_qso.getName().isEmpty())
+        QSOTabWidget->setName(_qso.getName());
+    if (!_qso.getRSTTX().isEmpty())
+        QSOTabWidget->setRSTTX(_qso.getRSTTX());
+    if (!_qso.getRSTRX().isEmpty())
+        QSOTabWidget->setRSTRX(_qso.getRSTRX());
+
+    mainQSOEntryWidget->setQRZ(_qso.getCall());
+    const QString udpBand = dataProxy->getBandNameFromFreq(_qso.getFreqTX());
+    if (!udpBand.isEmpty())
+        mainQSOEntryWidget->setBand(udpBand);
+    const QString udpMode = _qso.getSubmode().isEmpty() ? _qso.getMode() : _qso.getSubmode();
+    if (!udpMode.isEmpty())
+        mainQSOEntryWidget->setMode(udpMode);
+}
+
+void MainWindow::autoLogUDPQso(const QSO &_qso, const QDateTime &_arrivalTime)
+{
     QSO q;
-   //qDebug() << Q_FUNC_INFO << "020";
     q.copy(_qso);
     q.setLogId(currentLog);
 
-    // If the packet did not carry a valid time_on, stamp the QSO with the
-    // packet arrival time captured above so the DB record is correct.
     if (!q.getDateTimeOn().isValid())
-        q.setDateTimeOn(udpArrivalTime);
+        q.setDateTimeOn(_arrivalTime);
 
-    // The QSOLogged packet carries frequency but not band name.  Derive the
-    // band from the frequency so that isComplete() passes and addQSO() succeeds.
     if (q.getBand().isEmpty())
         q.setBand(dataProxy->getBandNameFromFreq(q.getFreqTX()));
 
-   //qDebug() << Q_FUNC_INFO << "030";
-   //qDebug() << Q_FUNC_INFO << "Call: " << q.getCall();
-   //qDebug() << Q_FUNC_INFO << "Mode: " << q.getMode();
-
     int dxcc = world->getQRZARRLId(q.getCall());
-     //qDebug() << Q_FUNC_INFO << "040";
-    dxcc = util->getNormalizedDXCCValue (dxcc);
-     //qDebug() << Q_FUNC_INFO << "050";
+    dxcc = util->getNormalizedDXCCValue(dxcc);
     q.setDXCC(dxcc);
     q.setClubLogStatus(clublogSentDefault);
     q.setLoTWQSL_SENT(lotwSentDefault);
     q.setEQSLQSL_SENT(eqslSentDefault);
     q.setQRZCOMStatus(qrzcomSentDefault);
-     //qDebug() << Q_FUNC_INFO << "060";
 
     if (!showWSJTXDuplicatedMSG(q))
         return;
 
-     //qDebug() << Q_FUNC_INFO << "070";
     int addedQSO = dataProxy->addQSO(q);
-   //qDebug() << Q_FUNC_INFO << "addedQSO: " << addedQSO;
-    if (addedQSO>0)
+    if (addedQSO > 0)
     {
-         //qDebug() << Q_FUNC_INFO << "090";
-         //qDebug() <<  Q_FUNC_INFO << " - QSO added: " << QString::number(addedQSO);
         actionsJustAfterAddingOneQSO(q);
         slotShowInfoLabel(tr("QSO logged from WSJT-X:"));
         infoLabel2->setText(q.getCall() + " - " + dataProxy->getBandNameFromFreq(q.getFreqTX()) + "/" + q.getSubmode());
-        // Remember UDP-sourced name and locator so they are preferred over QRZ.com
-        // for the same callsign after the form is cleared.
         udpLoggedCall    = q.getCall();
         udpLoggedName    = q.getName();
         udpLoggedLocator = q.getGridSquare();
         slotClearButtonClicked(Q_FUNC_INFO);
-        // Directly restore name/locator into the now-cleared form so the user
-        // can see who they just worked.  cleanQRZCOMreceivedDataFromUI() will
-        // also restore them if QRZ fires for the same callsign, but that path
-        // depends on a Status packet arriving — this one is unconditional.
         if (!udpLoggedName.isEmpty())
             QSOTabWidget->setName(udpLoggedName);
         if (!udpLoggedLocator.isEmpty())
             QSOTabWidget->setDXLocator(udpLoggedLocator);
     }
-
-     //qDebug() <<  Q_FUNC_INFO << " - END";
-    logEvent(Q_FUNC_INFO, "END", Debug);
 }
 
 bool MainWindow::askToAddQSOReceived(const QSO &_qso)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5663,12 +5663,9 @@ void MainWindow::slotShowQSOsFromDXCCWidget(QList<int> _qsos)
     mainQSOEntryWidget->setFreezeTime(true);
     mainQSOEntryWidget->setDateTime(udpArrivalTime);
 
-    // Populate form fields from the incoming QSO so that:
-    // (a) the confirmation dialog shows complete data, and
-    // (b) any field FreeDV did not send (e.g. name) can be filled by the
-    //     QRZ.com "Check always" lookup before the save reads them back.
-    // QRZ only overwrites fields that are empty (see slotElogQRZCOMFoundData),
-    // so setting name here prevents QRZ from replacing a name FreeDV did send.
+    // Populate form fields from the incoming QSO.  QRZ only overwrites fields
+    // that are empty (see slotElogQRZCOMFoundData), so setting name/comment
+    // here prevents QRZ from replacing values FreeDV already sent.
     if (!_qso.getComment().isEmpty())
         commentTabWidget->setData(_qso.getComment());
     if (!_qso.getName().isEmpty())
@@ -5679,11 +5676,20 @@ void MainWindow::slotShowQSOsFromDXCCWidget(QList<int> _qsos)
         QSOTabWidget->setRSTRX(_qso.getRSTRX());
 
     if (!wsjtxAutoLog)
-        if (!askToAddQSOReceived(_qso))
-        {
-            mainQSOEntryWidget->setFreezeTime(false);
-            return;
-        }
+    {
+        // Manual-add mode: populate the entry form so the user can review and
+        // edit before clicking Add.  The clock is already frozen at arrival
+        // time above; it will unfreeze when the form is cleared (Add or Clear).
+        // Do NOT call addQSO here — the normal Add button path saves the QSO.
+        mainQSOEntryWidget->setQRZ(_qso.getCall());
+        const QString udpBand = dataProxy->getBandNameFromFreq(_qso.getFreqTX());
+        if (!udpBand.isEmpty())
+            mainQSOEntryWidget->setBand(udpBand);
+        const QString udpMode = _qso.getSubmode().isEmpty() ? _qso.getMode() : _qso.getSubmode();
+        if (!udpMode.isEmpty())
+            mainQSOEntryWidget->setMode(udpMode);
+        return;
+    }
    //qDebug() << Q_FUNC_INFO << "010";
     QSO q;
    //qDebug() << Q_FUNC_INFO << "020";

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5650,12 +5650,18 @@ void MainWindow::slotShowQSOsFromDXCCWidget(QList<int> _qsos)
     udpLoggedName    = _qso.getName();
     udpLoggedLocator = _qso.getGridSquare();
 
-    // Freeze the real-time clock and show the QSO time from the UDP packet so the
-    // displayed time does not drift while the user reviews before clicking Add.
+    // FreeDV does not populate time_on in its QSOLogged packet, so capture the
+    // packet arrival time now as the best available QSO timestamp.
+    const QDateTime udpArrivalTime = _qso.getDateTimeOn().isValid()
+                                     ? _qso.getDateTimeOn()
+                                     : QDateTime::currentDateTimeUtc();
+
+    // Freeze the real-time clock at the packet arrival time so the displayed
+    // time does not drift while the user reviews before clicking Add.
     // Use setFreezeTime() rather than setRealTime(false) so that the realtime
     // checkbox state and settings are left untouched.
     mainQSOEntryWidget->setFreezeTime(true);
-    mainQSOEntryWidget->setDateTime(_qso.getDateTimeOn());
+    mainQSOEntryWidget->setDateTime(udpArrivalTime);
 
     // Populate form fields from the incoming QSO so that:
     // (a) the confirmation dialog shows complete data, and
@@ -5683,6 +5689,11 @@ void MainWindow::slotShowQSOsFromDXCCWidget(QList<int> _qsos)
    //qDebug() << Q_FUNC_INFO << "020";
     q.copy(_qso);
     q.setLogId(currentLog);
+
+    // If the packet did not carry a valid time_on, stamp the QSO with the
+    // packet arrival time captured above so the DB record is correct.
+    if (!q.getDateTimeOn().isValid())
+        q.setDateTimeOn(udpArrivalTime);
 
     // Supplement fields that _qso lacked but the form may now have
     // (e.g. name filled in by QRZ.com after the form was populated above).

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5644,8 +5644,7 @@ void MainWindow::slotShowQSOsFromDXCCWidget(QList<int> _qsos)
     //logEvent(Q_FUNC_INFO, "Start", Devel);
 
     // Latch UDP-sourced fields immediately so that cleanQRZCOMreceivedDataFromUI()
-    // can restore them if a QRZ.com lookup (or "Not found" error) fires before or
-    // during the Add confirmation dialog — even if the user never clicks Add.
+    // can restore them if a QRZ.com lookup fires before or after the form is populated.
     udpLoggedCall    = _qso.getCall();
     udpLoggedName    = _qso.getName();
     udpLoggedLocator = _qso.getGridSquare();
@@ -5656,31 +5655,31 @@ void MainWindow::slotShowQSOsFromDXCCWidget(QList<int> _qsos)
                                      ? _qso.getDateTimeOn()
                                      : QDateTime::currentDateTimeUtc();
 
-    // Freeze the real-time clock at the packet arrival time so the displayed
-    // time does not drift while the user reviews before clicking Add.
-    // Use setFreezeTime() rather than setRealTime(false) so that the realtime
-    // checkbox state and settings are left untouched.
-    mainQSOEntryWidget->setFreezeTime(true);
-    mainQSOEntryWidget->setDateTime(udpArrivalTime);
-
-    // Populate form fields from the incoming QSO.  QRZ only overwrites fields
-    // that are empty (see slotElogQRZCOMFoundData), so setting name/comment
-    // here prevents QRZ from replacing values FreeDV already sent.
-    if (!_qso.getComment().isEmpty())
-        commentTabWidget->setData(_qso.getComment());
-    if (!_qso.getName().isEmpty())
-        QSOTabWidget->setName(_qso.getName());
-    if (!_qso.getRSTTX().isEmpty())
-        QSOTabWidget->setRSTTX(_qso.getRSTTX());
-    if (!_qso.getRSTRX().isEmpty())
-        QSOTabWidget->setRSTRX(_qso.getRSTRX());
-
     if (!wsjtxAutoLog)
     {
-        // Manual-add mode: populate the entry form so the user can review and
-        // edit before clicking Add.  The clock is already frozen at arrival
-        // time above; it will unfreeze when the form is cleared (Add or Clear).
+        // Don't overwrite a QSO the user is currently editing or a manual-mode session.
+        if (modify || manualMode)
+            return;
+
+        // Manual-add mode: freeze the clock at packet arrival time and populate the
+        // entry form so the user can review and edit before clicking Add.
+        // The clock unfreezes when the form is cleared (Add or Clear).
         // Do NOT call addQSO here — the normal Add button path saves the QSO.
+        mainQSOEntryWidget->setFreezeTime(true);
+        mainQSOEntryWidget->setDateTime(udpArrivalTime);
+
+        // Populate form fields.  QRZ only overwrites empty fields (see
+        // slotElogQRZCOMFoundData), so setting name/comment/RST here preserves
+        // values that FreeDV already provided against QRZ.com overwriting them.
+        if (!_qso.getComment().isEmpty())
+            commentTabWidget->setData(_qso.getComment());
+        if (!_qso.getName().isEmpty())
+            QSOTabWidget->setName(_qso.getName());
+        if (!_qso.getRSTTX().isEmpty())
+            QSOTabWidget->setRSTTX(_qso.getRSTTX());
+        if (!_qso.getRSTRX().isEmpty())
+            QSOTabWidget->setRSTRX(_qso.getRSTRX());
+
         mainQSOEntryWidget->setQRZ(_qso.getCall());
         const QString udpBand = dataProxy->getBandNameFromFreq(_qso.getFreqTX());
         if (!udpBand.isEmpty())
@@ -5690,6 +5689,8 @@ void MainWindow::slotShowQSOsFromDXCCWidget(QList<int> _qsos)
             mainQSOEntryWidget->setMode(udpMode);
         return;
     }
+
+    // Auto-log path: save directly to DB without touching the form.
    //qDebug() << Q_FUNC_INFO << "010";
     QSO q;
    //qDebug() << Q_FUNC_INFO << "020";
@@ -5706,12 +5707,6 @@ void MainWindow::slotShowQSOsFromDXCCWidget(QList<int> _qsos)
     if (q.getBand().isEmpty())
         q.setBand(dataProxy->getBandNameFromFreq(q.getFreqTX()));
 
-    // Supplement fields that _qso lacked but the form may now have
-    // (e.g. name filled in by QRZ.com after the form was populated above).
-    if (q.getName().isEmpty())
-        q.setName(QSOTabWidget->getName());
-    if (q.getComment().isEmpty())
-        q.setComment(commentTabWidget->getComment());
    //qDebug() << Q_FUNC_INFO << "030";
    //qDebug() << Q_FUNC_INFO << "Call: " << q.getCall();
    //qDebug() << Q_FUNC_INFO << "Mode: " << q.getMode();
@@ -5728,13 +5723,9 @@ void MainWindow::slotShowQSOsFromDXCCWidget(QList<int> _qsos)
      //qDebug() << Q_FUNC_INFO << "060";
 
     if (!showWSJTXDuplicatedMSG(q))
-    {
-        mainQSOEntryWidget->setFreezeTime(false);
         return;
-    }
 
      //qDebug() << Q_FUNC_INFO << "070";
-    //int addedQSO = q.toDB();
     int addedQSO = dataProxy->addQSO(q);
    //qDebug() << Q_FUNC_INFO << "addedQSO: " << addedQSO;
     if (addedQSO>0)
@@ -5758,13 +5749,6 @@ void MainWindow::slotShowQSOsFromDXCCWidget(QList<int> _qsos)
             QSOTabWidget->setName(udpLoggedName);
         if (!udpLoggedLocator.isEmpty())
             QSOTabWidget->setDXLocator(udpLoggedLocator);
-        // Resume the real-time clock now the QSO has been logged and the form cleared.
-        mainQSOEntryWidget->setFreezeTime(false);
-    }
-    else
-    {
-         //qDebug() << Q_FUNC_INFO << "100";
-        mainQSOEntryWidget->setFreezeTime(false);
     }
 
      //qDebug() <<  Q_FUNC_INFO << " - END";

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -293,6 +293,10 @@ void MainWindow::init_variables()
     stationCallsign = "";
     mainQRZ = "";
     dxLocator ="";
+    udpLoggedName = "";
+    udpLoggedLocator = "";
+    udpLoggedCall = "";
+    udpSavedRealTime = true;
 
     UDPServerStart = false;   // By default the UDP server is started
 
@@ -1845,6 +1849,16 @@ void MainWindow::cleanQRZCOMreceivedDataFromUI()
     if (!modify)
     {
         QSOTabWidget->cleanQRZCOM(true);
+        // If we have name/locator from a recent UDP-logged QSO for the current
+        // callsign, restore them immediately after the clean so QRZ.com cannot
+        // overwrite values that FreeDV already provided.
+        if (udpLoggedCall.toUpper() == mainQSOEntryWidget->getQrz().toUpper())
+        {
+            if (!udpLoggedName.isEmpty())
+                QSOTabWidget->setName(udpLoggedName);
+            if (!udpLoggedLocator.isEmpty())
+                QSOTabWidget->setDXLocator(udpLoggedLocator);
+        }
     }
     completedWithPreviousName = false;
     completedWithPreviousLocator = false;
@@ -1896,7 +1910,12 @@ void MainWindow::slotElogQRZCOMFoundData(const QString &_t, const QString & _d)
        if (QSOTabWidget->getName().length()<1)
        {
            qrzAutoChanging = true;
-           QSOTabWidget->setName(_d);
+           // If we have a name from a recent UDP-logged QSO for this callsign, use it
+           // instead of the QRZ.com name so the FreeDV-exchanged name is preserved.
+           const QString nameToUse = (!udpLoggedName.isEmpty() &&
+                                      udpLoggedCall.toUpper() == mainQSOEntryWidget->getQrz().toUpper())
+                                     ? udpLoggedName : _d;
+           QSOTabWidget->setName(nameToUse);
            qrzAutoChanging = false;
        }
    }
@@ -2035,6 +2054,9 @@ void MainWindow::slotQRZTextChanged(QString _qrz)
          //qDebug()<< Q_FUNC_INFO << " - 11" ;
         infoLabel1->clear();
         infoLabel2->clear();
+        // Reset so the next callsign entry always runs the full path through
+        // cleanQRZCOMreceivedDataFromUI, restoring any UDP-sourced fields.
+        qrzSmallModDontCalculate = false;
         slotClearButtonClicked(Q_FUNC_INFO);
         logEvent(Q_FUNC_INFO, "END-Empty", Devel);
         return;
@@ -2047,6 +2069,16 @@ void MainWindow::slotQRZTextChanged(QString _qrz)
         return;
     }
      //qDebug()<< Q_FUNC_INFO << " - 30" ;
+
+    // If the callsign has changed to a different (non-empty) station, forget the
+    // UDP-sourced name and locator.  An empty callsign means the form was just
+    // cleared — keep them so they survive the clear and the next Status message
+    // can use them.
+    if (!_qrz.isEmpty() && _qrz.toUpper() != udpLoggedCall.toUpper())
+    {
+        udpLoggedName.clear();
+        udpLoggedLocator.clear();
+    }
 
     // Query QRZ.com whenever the callsign changes, in both normal and modify (edit) mode.
     // The response is validated against the current callsign in slotElogQRZCOMFoundData,
@@ -5611,14 +5643,53 @@ void MainWindow::slotShowQSOsFromDXCCWidget(QList<int> _qsos)
     //qDebug() <<  Q_FUNC_INFO << " - Start";
     //logEvent(Q_FUNC_INFO, "Start", Devel);
 
+    // Latch UDP-sourced fields immediately so that cleanQRZCOMreceivedDataFromUI()
+    // can restore them if a QRZ.com lookup (or "Not found" error) fires before or
+    // during the Add confirmation dialog — even if the user never clicks Add.
+    udpLoggedCall    = _qso.getCall();
+    udpLoggedName    = _qso.getName();
+    udpLoggedLocator = _qso.getGridSquare();
+
+    // Freeze the real-time clock and show the QSO time from the UDP packet so the
+    // displayed time does not drift while the user reviews before clicking Add.
+    // Use setFreezeTime() rather than setRealTime(false) so that the realtime
+    // checkbox state and settings are left untouched.
+    mainQSOEntryWidget->setFreezeTime(true);
+    mainQSOEntryWidget->setDateTime(_qso.getDateTimeOn());
+
+    // Populate form fields from the incoming QSO so that:
+    // (a) the confirmation dialog shows complete data, and
+    // (b) any field FreeDV did not send (e.g. name) can be filled by the
+    //     QRZ.com "Check always" lookup before the save reads them back.
+    // QRZ only overwrites fields that are empty (see slotElogQRZCOMFoundData),
+    // so setting name here prevents QRZ from replacing a name FreeDV did send.
+    if (!_qso.getComment().isEmpty())
+        commentTabWidget->setData(_qso.getComment());
+    if (!_qso.getName().isEmpty())
+        QSOTabWidget->setName(_qso.getName());
+    if (!_qso.getRSTTX().isEmpty())
+        QSOTabWidget->setRSTTX(_qso.getRSTTX());
+    if (!_qso.getRSTRX().isEmpty())
+        QSOTabWidget->setRSTRX(_qso.getRSTRX());
+
     if (!wsjtxAutoLog)
         if (!askToAddQSOReceived(_qso))
+        {
+            mainQSOEntryWidget->setFreezeTime(false);
             return;
+        }
    //qDebug() << Q_FUNC_INFO << "010";
     QSO q;
    //qDebug() << Q_FUNC_INFO << "020";
     q.copy(_qso);
     q.setLogId(currentLog);
+
+    // Supplement fields that _qso lacked but the form may now have
+    // (e.g. name filled in by QRZ.com after the form was populated above).
+    if (q.getName().isEmpty())
+        q.setName(QSOTabWidget->getName());
+    if (q.getComment().isEmpty())
+        q.setComment(commentTabWidget->getComment());
    //qDebug() << Q_FUNC_INFO << "030";
    //qDebug() << Q_FUNC_INFO << "Call: " << q.getCall();
    //qDebug() << Q_FUNC_INFO << "Mode: " << q.getMode();
@@ -5635,7 +5706,10 @@ void MainWindow::slotShowQSOsFromDXCCWidget(QList<int> _qsos)
      //qDebug() << Q_FUNC_INFO << "060";
 
     if (!showWSJTXDuplicatedMSG(q))
+    {
+        mainQSOEntryWidget->setFreezeTime(false);
         return;
+    }
 
      //qDebug() << Q_FUNC_INFO << "070";
     //int addedQSO = q.toDB();
@@ -5648,11 +5722,27 @@ void MainWindow::slotShowQSOsFromDXCCWidget(QList<int> _qsos)
         actionsJustAfterAddingOneQSO(q);
         slotShowInfoLabel(tr("QSO logged from WSJT-X:"));
         infoLabel2->setText(q.getCall() + " - " + dataProxy->getBandNameFromFreq(q.getFreqTX()) + "/" + q.getSubmode());
+        // Remember UDP-sourced name and locator so they are preferred over QRZ.com
+        // for the same callsign after the form is cleared.
+        udpLoggedCall    = q.getCall();
+        udpLoggedName    = q.getName();
+        udpLoggedLocator = q.getGridSquare();
         slotClearButtonClicked(Q_FUNC_INFO);
+        // Directly restore name/locator into the now-cleared form so the user
+        // can see who they just worked.  cleanQRZCOMreceivedDataFromUI() will
+        // also restore them if QRZ fires for the same callsign, but that path
+        // depends on a Status packet arriving — this one is unconditional.
+        if (!udpLoggedName.isEmpty())
+            QSOTabWidget->setName(udpLoggedName);
+        if (!udpLoggedLocator.isEmpty())
+            QSOTabWidget->setDXLocator(udpLoggedLocator);
+        // Resume the real-time clock now the QSO has been logged and the form cleared.
+        mainQSOEntryWidget->setFreezeTime(false);
     }
     else
     {
          //qDebug() << Q_FUNC_INFO << "100";
+        mainQSOEntryWidget->setFreezeTime(false);
     }
 
      //qDebug() <<  Q_FUNC_INFO << " - END";

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -357,6 +357,8 @@ private:
     bool setHamlib(const bool _b);
     bool setUDPServer(const bool _b);
     bool askToAddQSOReceived(const QSO &_qso);  // Shows a message with the data of the QSO
+    void populateFormFromUDPQso(const QSO &_qso, const QDateTime &_arrivalTime);
+    void autoLogUDPQso(const QSO &_qso, const QDateTime &_arrivalTime);
 
     void ensureTipsDialog();
     void setLogLevel(const DebugLogLevel _sev);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -676,6 +676,10 @@ private:
     bool qrzcomResponseValid; // True when the QRZ.com response callsign matches the current UI callsign
     bool m_adifImporting = false; // True while processing post-ADIF-import updates, to prevent double DXCC refresh
     QString mainQRZ, stationCallsign, operatorQRZ, dxLocator;
+    QString udpLoggedName;    // Name from the most recently UDP-logged QSO (e.g. FreeDV)
+    QString udpLoggedLocator; // Locator from the most recently UDP-logged QSO
+    QString udpLoggedCall;    // Callsign of that QSO — used to match against the current UI callsign
+    bool udpSavedRealTime;    // Real-time checkbox state saved when a UDP QSO freezes the clock
 
     int my_CQz, my_ITUz;
     int defaultMode, defaultBand, currentMode, currentModeShown, currentBand, currentBandShown;


### PR DESCRIPTION
Summary

  Integrates KLog with FreeDV's UDP QSOLogged packet (message type 5), allowing a completed FreeDV QSO to be captured into the KLog entry form for review
  before the operator clicks Add to save it — the same workflow as a manual entry.

  Changes

  src/udpserver.cpp — The existing WSJT-X UDP server already handled the QSOLogged packet and emitted the logged(qso) signal. FreeDV sends the same packet
  type, so no protocol changes were needed; the work is entirely in how KLog responds to that signal.

  src/mainwindow.cpp — slotQSOReceived

  - Band derivation from frequency. FreeDV's QSOLogged packet carries the operating frequency but not the band name. QSO::isComplete() requires haveBand =
  true, so addQSO() was silently returning −1. The fix derives the band name from the frequency via getBandNameFromFreq() before any save attempt.
  - Packet arrival time as QSO timestamp. FreeDV does not populate time_on in its QSOLogged packet. The arrival time of the packet is now captured
  immediately as udpArrivalTime and used as the QSO timestamp, giving an accurate start time rather than whatever time the user eventually clicks Add.
  - Populate-form mode instead of auto-save. When the Auto-log from WSJT-X setting is off (the appropriate setting for FreeDV, which has no auto-log option
  of its own), the previous code showed a confirmation dialog and then saved anyway. This is replaced with proper populate-form behaviour: callsign, band,
  mode, time, RST, name, and comment are all written into the entry form, the clock is frozen at arrival time, and control returns to the user. The QSO is
  saved only when the operator clicks Add, exactly as for a manual entry.
  - Edit-mode guard. If the entry form is already in edit mode (modify) or manual mode (manualMode) when a packet arrives — for example because the operator
   is correcting a previous log entry — the packet is silently dropped rather than overwriting the in-progress work. This mirrors the behaviour of the
  existing Status packet handler.
  - Clock freeze/unfreeze scoping. setFreezeTime(true) and the associated setDateTime() call are now scoped inside the populate-form path only. The auto-log
   path saves directly to the database and never touches the form, so the freeze was unnecessary and has been removed from that path.
  - UDP-sourced name and locator protection. The udpLoggedCall, udpLoggedName, and udpLoggedLocator fields are latched at packet arrival.
  cleanQRZCOMreceivedDataFromUI() and slotElogQRZCOMFoundData() use these to restore FreeDV-provided values if a QRZ.com lookup fires concurrently and would
   otherwise overwrite them.

  src/mainqsoentrywidget.cpp — clear()

  Added freezeTime = false to the clear() method so the clock freeze is released when the form is cleared (whether by clicking Add or Clear), allowing
  real-time updating to resume for the next QSO.

  Behaviour
<img width="1111" height="132" alt="image" src="https://github.com/user-attachments/assets/6fe5ee9e-118b-4617-a50f-10dbf1705052" />
