### PR TITLE
Run hamlib initialization asynchronously to prevent UI freezing

### DIFF
--- a/src/hamlibclass.cpp
+++ b/src/hamlibclass.cpp
@@ -395,6 +395,13 @@ void HamLibClass::slotTimer()
     //qDebug() << Q_FUNC_INFO << " - END";
 }
 
+void HamLibClass::startPolling()
+{
+    logEvent(Q_FUNC_INFO, "Start", Devel);
+    if (timer && rig_state == RigState::Connected)
+        timer->start(pollInterval);
+}
+
 void HamLibClass::setMode(const QString &_m)
 {
     logEvent(Q_FUNC_INFO, "Start", Devel);
@@ -691,11 +698,6 @@ bool HamLibClass::init(bool _active)
         //connected = true;
 
         probeSplitVfoSideEffect();
-
-        // ¡IMPORTANTE! Iniciar el polling si la conexión tuvo éxito
-        if (_active && timer) {
-            timer->start(pollInterval);
-        }
         return true;
 
     } else {

--- a/src/hamlibclass.h
+++ b/src/hamlibclass.h
@@ -109,6 +109,7 @@ signals:
 
 public slots:
     void slotTimer();
+    void startPolling();
 
 
 private:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3394,7 +3394,34 @@ void MainWindow::slotSetupDialogFinished (const int _s)
     // (the test connects a second hamlib instance which may disrupt the live session).
     if (setupDialog->hamlibSettingsChanged() || setupDialog->hamlibTestWasRun())
     {
-        hamlibActive = setHamlib(hamlibActive);
+        const bool shouldConnect = hamlibActive;
+        if (shouldConnect)
+        {
+            // Run the blocking TCP reconnect in background so the main window
+            // is not frozen while hamlib establishes the new connection.
+            auto *watcher = new QFutureWatcher<bool>(this);
+            connect(watcher, &QFutureWatcher<bool>::finished, this, [this, watcher]() {
+                const bool ok = watcher->result();
+                watcher->deleteLater();
+                hamlibActive = ok;
+                if (ok)
+                {
+                    hamlib->startPolling();
+                    hamlib->forceRead();
+                }
+            });
+            QFuture<bool> future = QtConcurrent::run([this]() {
+                if (!upAndRunning)
+                    return false;
+                return hamlib->init(true);
+            });
+            watcher->setFuture(future);
+        }
+        else
+        {
+            hamlib->init(false);
+            hamlibActive = false;
+        }
     }
 
    //qDebug() << (QTime::currentTime()).toString ("HH:mm:ss") << Q_FUNC_INFO << " - END";
@@ -3526,6 +3553,7 @@ bool MainWindow::setHamlib(const bool _b)
         if (!hamlib->init(true))
             return false;
           //qDebug() << (QTime::currentTime()).toString ("HH:mm:ss - ")  << Q_FUNC_INFO << ": After Hamlib active";
+        hamlib->startPolling();
         return hamlib->readRadio(); // Forcing the radio update
     }
     else
@@ -3547,7 +3575,7 @@ void MainWindow::showEvent(QShowEvent *event)
         hamlibConnectionAttempted = true;
         QTimer::singleShot(0, this, &MainWindow::slotInitHamlib);
         QTimer::singleShot(100, this, &MainWindow::checkIfNewVersion);
-        QTimer::singleShot(200, this, &MainWindow::recommendBackupIfNeeded);
+        // recommendBackupIfNeeded is called from slotInitHamlib once hamlib init completes
         QTimer::singleShot(300, this, [this]{ checkVersions(); }); //
     }
 }
@@ -3555,35 +3583,63 @@ void MainWindow::showEvent(QShowEvent *event)
 void MainWindow::slotInitHamlib()
 {
     if (!hamlibActive)
-        return;
-    hamlibActive = setHamlib(true);
-
-    if (!hamlibActive)
     {
-        hamlib->stop();  // Stop polling timer so it doesn't trigger a second "lost communication" dialog
-        logEvent(Q_FUNC_INFO, "HamLib connection failed on startup", Warning);
-
-        QMessageBox msgBox(this);
-        msgBox.setIcon(QMessageBox::Warning);
-        msgBox.setWindowTitle(tr("Radio connection failed"));
-        msgBox.setText(tr("KLog could not connect to the radio at startup."));
-        msgBox.setInformativeText(tr("Please check the radio is on and the port settings are correct.\n"
-                                     "You can reconfigure and test the connection in Setup → Hamlib.\n\n"
-                                     "Do you want KLog to try to connect automatically on next startup?"));
-        msgBox.addButton(tr("Yes, reconnect on startup"), QMessageBox::YesRole);
-        QPushButton *noButton = msgBox.addButton(tr("No, disable radio connection"), QMessageBox::NoRole);
-        msgBox.exec();
-
-        if (msgBox.clickedButton() == noButton)
-        {
-            QSettings settings(util->getCfgFile(), QSettings::IniFormat);
-            settings.beginGroup("HamLib");
-            settings.setValue("HamLibActive", false);
-            settings.endGroup();
-            settings.sync();
-            logEvent(Q_FUNC_INFO, "HamLibActive set to false by user after startup failure", Info);
-        }
+        // Hamlib not configured — still fire the deferred startup tasks
+        recommendBackupIfNeeded();
+        return;
     }
+
+    // Run the blocking TCP connect in a background thread so the UI stays
+    // responsive while hamlib is establishing the connection.
+    auto *watcher = new QFutureWatcher<bool>(this);
+    connect(watcher, &QFutureWatcher<bool>::finished, this, [this, watcher]() {
+        const bool ok = watcher->result();
+        watcher->deleteLater();
+
+        hamlibActive = ok;
+        if (ok)
+        {
+            // Timer must be started on the main thread (QTimer affinity).
+            hamlib->startPolling();
+            hamlib->forceRead();
+        }
+        else
+        {
+            hamlib->stop();
+            logEvent(Q_FUNC_INFO, "HamLib connection failed on startup", Warning);
+
+            QMessageBox msgBox(this);
+            msgBox.setIcon(QMessageBox::Warning);
+            msgBox.setWindowTitle(tr("Radio connection failed"));
+            msgBox.setText(tr("KLog could not connect to the radio at startup."));
+            msgBox.setInformativeText(tr("Please check the radio is on and the port settings are correct.\n"
+                                         "You can reconfigure and test the connection in Setup → Hamlib.\n\n"
+                                         "Do you want KLog to try to connect automatically on next startup?"));
+            msgBox.addButton(tr("Yes, reconnect on startup"), QMessageBox::YesRole);
+            QPushButton *noButton = msgBox.addButton(tr("No, disable radio connection"), QMessageBox::NoRole);
+            msgBox.exec();
+
+            if (msgBox.clickedButton() == noButton)
+            {
+                QSettings settings(util->getCfgFile(), QSettings::IniFormat);
+                settings.beginGroup("HamLib");
+                settings.setValue("HamLibActive", false);
+                settings.endGroup();
+                settings.sync();
+                logEvent(Q_FUNC_INFO, "HamLibActive set to false by user after startup failure", Info);
+            }
+        }
+
+        // Always fire deferred startup tasks after hamlib init (success or failure).
+        recommendBackupIfNeeded();
+    });
+
+    QFuture<bool> future = QtConcurrent::run([this]() {
+        if (!upAndRunning)
+            return false;
+        return hamlib->init(true);
+    });
+    watcher->setFuture(future);
 }
 
 void MainWindow::slotHamlibRigDisconnected()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -154,7 +154,7 @@ MainWindow::MainWindow(DataProxy_SQLite *dp, World *injectedWorld):
        exit(0);
     }
 
-    softUpdate = new SoftwareUpdate(softwareVersion);
+    softUpdate = new SoftwareUpdate(softwareVersion, this);
    //qInfo() << "[KLOG-TIMING] ctor 031 - SoftwareUpdate:" << timer.elapsed() << "ms"; timer.restart();
 
     filemanager = new FileManager(dataProxy, world);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -31,6 +31,8 @@
 #include <QPrintDialog>
 #include <QNetworkRequest>
 #include <QNetworkReply>
+#include <QtConcurrent>
+#include <QFutureWatcher>
 #include <QtAlgorithms>
 #include <QDesktopServices>
 #include <QUrl>

--- a/src/setuppages/setuppagehamlib.cpp
+++ b/src/setuppages/setuppagehamlib.cpp
@@ -103,8 +103,10 @@ void SetupPageHamLib::slotTestHamlib()
     m_liveHamlib->stop();
     freqDisplayLabel->setText(defaultFreqMode);
     bool ok = m_liveHamlib->init(true);
-    if (ok)
+    if (ok) {
+        m_liveHamlib->startPolling();
         ok = m_liveHamlib->forceRead();
+    }
     setTestResult(ok);
     if (!ok)
         m_liveHamlib->stop();

--- a/src/softwareupdate.cpp
+++ b/src/softwareupdate.cpp
@@ -26,11 +26,11 @@
 
 #include "softwareupdate.h"
 
-SoftwareUpdate::SoftwareUpdate(const QString &_klogVersion) : QObject(nullptr)
+SoftwareUpdate::SoftwareUpdate(const QString &_klogVersion, QWidget *parent) : QObject(parent)
 {
       //qDebug() << "SoftwareUpdate::SoftwareUpdate(): " << _klogVersion;
     util = new Utilities(Q_FUNC_INFO);
-    updateDialog = new SoftwareUpdateDialog();
+    updateDialog = new SoftwareUpdateDialog(parent);
     latestVersion = "0.0";
     repositoryFound = false;
     url = new QUrl;
@@ -127,8 +127,8 @@ void SoftwareUpdate::slotDownloadFinished(QNetworkReply *reply)
                 {
                     //qDebug() << "SoftwareUpdate::slotDownloadFinished checkupdates should update!" ;
                     updateDialog->setVersion(latestVersion, true);
+                    updateDialog->show();
                 }
-                updateDialog->show();
                 latestVersion = klogVersion;
                 repositoryFound = false;
             }

--- a/src/softwareupdate.h
+++ b/src/softwareupdate.h
@@ -43,7 +43,7 @@ class SoftwareUpdate: public QObject {
     Q_OBJECT
 
 public:
-    SoftwareUpdate(const QString &_klogVersion);
+    explicit SoftwareUpdate(const QString &_klogVersion, QWidget *parent = nullptr);
     ~SoftwareUpdate();
 
     void addCall(const QString &_call);

--- a/src/softwareupdatedialog.cpp
+++ b/src/softwareupdatedialog.cpp
@@ -28,7 +28,7 @@
 
 //#include <QDebug>
 
-SoftwareUpdateDialog::SoftwareUpdateDialog()
+SoftwareUpdateDialog::SoftwareUpdateDialog(QWidget *parent) : QDialog(parent)
 {
       //qDebug() << "SoftwareUpdateDialog::SoftwareUpdateDialog" ;
 
@@ -92,10 +92,14 @@ void SoftwareUpdateDialog::slotAcceptButtonClicked()
 void SoftwareUpdateDialog::keyPressEvent(QKeyEvent *event)
 {
     //qDebug() << "SoftwareUpdateDialog::keyPressEvent" ;
-
-    if (event->key()>=0)
+    if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter ||
+        event->key() == Qt::Key_Escape)
     {
         slotAcceptButtonClicked();
+    }
+    else
+    {
+        QDialog::keyPressEvent(event);
     }
     //qDebug() << "SoftwareUpdateDialog::keyPressEvent END" ;
 }

--- a/src/softwareupdatedialog.h
+++ b/src/softwareupdatedialog.h
@@ -33,7 +33,7 @@ class SoftwareUpdateDialog: public QDialog
 {
     Q_OBJECT
 public:
-    SoftwareUpdateDialog();
+    explicit SoftwareUpdateDialog(QWidget *parent = nullptr);
     ~SoftwareUpdateDialog();
     void setVersion(const QString tversion, const bool updateNeeded);
 


### PR DESCRIPTION
## Summary
This PR refactors hamlib initialization to run asynchronously in background threads, preventing the main UI from freezing during TCP connection establishment. It also improves dialog parent ownership and fixes several related issues.

## Key Changes

- **Asynchronous hamlib initialization**: Moved blocking `hamlib->init()` calls to background threads using `QtConcurrent::run()` with `QFutureWatcher` in both startup (`slotInitHamlib`) and setup dialog completion (`slotSetupDialogFinished`) flows
- **Deferred polling start**: Extracted polling timer start into a new `HamLibClass::startPolling()` method that runs on the main thread after async initialization completes
- **Improved dialog ownership**: 
  - Pass parent widget to `SoftwareUpdate` and `SoftwareUpdateDialog` constructors for proper memory management and window modality
  - Update constructors to use `explicit` keyword and accept optional parent parameter
- **Fixed software update dialog display**: Only show update dialog when an update is actually needed (moved `show()` call inside the condition)
- **Enhanced key event handling**: Improved `SoftwareUpdateDialog::keyPressEvent()` to properly handle Return/Enter/Escape keys and delegate other events to parent class
- **Startup task ordering**: Moved `recommendBackupIfNeeded()` call to execute after hamlib initialization completes (success or failure) rather than on a fixed timer

## Implementation Details

- Uses `QtConcurrent::run()` to execute hamlib connection in thread pool
- `QFutureWatcher` callbacks handle result processing and UI updates on main thread
- Polling timer is explicitly started only after successful connection, preventing premature polling attempts
- Maintains backward compatibility with existing hamlib API
- Includes necessary Qt Concurrent headers in mainwindow.h

https://claude.ai/code/session_013RptyoXN8AV3acPCSpVqU5