### PR TITLE
Fix orphaned shared memory cleanup on Linux/Unix systems

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -211,13 +211,13 @@ int main(int argc, char *argv[])
     semaphore.acquire();                       // Raise the semaphore, barring other instances to work with shared memory
 
 #ifndef KLOG_Q_OS_WIN
-    QSharedMemory nix_fix_shared_memory("klogshm");
-    if (nix_fix_shared_memory.error() == QSharedMemory::AlreadyExists)
+    // On Linux/Unix, a crashed process leaves its shared memory segment in /dev/shm.
+    // Unconditionally attach then detach: if an orphaned segment exists it is released;
+    // if no segment exists, attach() fails silently and detach() is a no-op.
     {
-    // if the failure is caused by the shm segment already existing we need
-    // to attach to it before detaching from it.
+        QSharedMemory nix_fix_shared_memory("klogshm");
         nix_fix_shared_memory.attach();
-        nix_fix_shared_memory.detach(); // if there is no running instance then it remove the orphaned shared memory
+        nix_fix_shared_memory.detach();
     }
 #endif
 


### PR DESCRIPTION
## Summary
Refactored the shared memory cleanup logic on Linux/Unix systems to be more robust and clearer in intent. The code now unconditionally attempts to attach and detach from the shared memory segment, which properly handles both cases: orphaned segments from crashed processes and non-existent segments.

## Key Changes
- Removed the conditional check for `QSharedMemory::AlreadyExists` error
- Restructured the code to always attempt attach/detach operations within a scope block
- Improved code comments to explain the Linux/Unix-specific behavior and why unconditional attach/detach is the correct approach
- Simplified the logic: `attach()` fails silently if no segment exists, and `detach()` is a no-op if not attached

## Implementation Details
The previous implementation only attempted cleanup if an error was detected, which was fragile. The new approach leverages Qt's behavior where:
- `attach()` will succeed if an orphaned segment exists (allowing it to be detached and released)
- `attach()` will fail silently if no segment exists (no error thrown)
- `detach()` is safe to call regardless of attachment state

This ensures orphaned shared memory segments left behind by crashed processes are properly cleaned up on application startup, while also handling the case where no segment exists.

https://claude.ai/code/session_019M8bvkofdCtM7ao7opvLBh