### PR TITLE
Set CQ zone from DXCC when adding QSO

### DIFF
--- a/src/dataproxy_sqlite.cpp
+++ b/src/dataproxy_sqlite.cpp
@@ -2401,6 +2401,13 @@ int DataProxy_SQLite::addQSO(QSO &_qso)
     if (!_qso.isComplete())
         return -1;
     _qso.clearQSLDateIfNeeded();
+    if ((_qso.getCQZone() <= 0) && (_qso.getDXCC() > 0))
+    {
+        const int entityCQz = getCQzFromEntity(_qso.getDXCC());
+        if (entityCQz > 0)
+            _qso.setCQZone(entityCQz);
+    }
+
 
     prepareStaticQueries();
     if (!m_queriesPrepared)


### PR DESCRIPTION
This fixes new QSOs where DXCC is already known but CQZ remains 0.

When adding a QSO, if CQ zone is empty or 0 and DXCC is available, KLog now fills CQZ from the entity table.

Tested with QSOs where:
- DXCC 248 Italy now gets CQZ 15
- DXCC 227 France now gets CQZ 14

This prevents new imported/logged QSOs from being saved with CQZ=0.