### PR TITLE
Check the WSJT-X stations against the DX Assistant

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,7 @@ TBD - 2.5.4
 - New feature: DX Assistant, a tab in the upper-right panel (enable it in Setup, in the DXCluster page) showing a live, prioritised list of DXCluster spots scored against your own log, with a Priority column, per-session spot hiding, band/spotter-continent filters, configurable max age and max number of spots (Closes #1009, #1010, #1011, #1012, #1013, #1014, #1015, #1016, #1017, #1018)
 - New feature: The DX Assistant shows the most active band and the "band to be" (Closes #796, #860, #1019)
 - Enhancement: A "DX A" button in the DXCluster widget, next to Clear, enables and disables the DX Assistant without going through Setup.
+- Enhancement: The stations WSJT-X sends to KLog are checked against the DX Assistant just like the DXCluster spots, so they are scored and listed with the rest of the spots.
 - Enhancement: The DX Assistant has a single context menu, reachable from both the spot list and the column header, replacing the two separate menus and the "Clear hidden spots" button (which now gives its space to the spot table). It adds Copy Callsign, a "Follow my band" filter that tracks the band you are working on, Status and DXCC filters, a spotter filter with My continent / My DXCC / ALL, "QSY to this freq" when a radio is connected, Clear all, Show to map and Refresh.
 - Enhancement: KLog can import many ADI files in one single operation by simply selecting them.
 - Bugfix: Fix BAND_RX export when RX band is empty (TNX YL3GBC)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -310,6 +310,8 @@ void MainWindow::init_variables()
     udpLoggedLocator = "";
     udpLoggedCall = "";
     udpSavedRealTime = true;
+    wsjtxLastSpotKey = "";
+    wsjtxLastSpotDateTime = QDateTime();
 
     UDPServerStart = false;   // By default the UDP server is started
 
@@ -5404,6 +5406,45 @@ void MainWindow::slotDXAssistantNewSpot(const DXSpot &_spot)
         dxClusterAssistant->addOrUpdateSpot(spot);
 }
 
+void MainWindow::checkWSJTXSpotWithDXAssistant(const QString &_dxCall, const double _freq,
+                                               const QString &_mode, const QString &_spotter)
+{
+    // A station arriving from WSJT-X and shown in the UI deserves the same
+    // treatment as a DXCluster spot: it is scored by the DX Assistant engine
+    // and, if it is worth working, it shows up in the DX Assistant tab.
+    if (!dxAssistantEnabled || (dxAssistantEngine == nullptr) || (dxClusterAssistant == nullptr))
+        return;
+    if (_dxCall.isEmpty() || (_freq <= 0.0))
+        return;
+
+    // WSJT-X repeats its status message about once per second while the same
+    // station is selected. Feeding every one of them would flood the raw
+    // activity tally behind "Most active band", so the spot is only handed
+    // over when the station changes or often enough to keep the entry from
+    // ageing out of the list while WSJT-X is still showing it.
+    const QDateTime now = QDateTime::currentDateTimeUtc();
+    const QString spotKey = _dxCall.toUpper() + "-" + QString::number(_freq, 'f', 6);
+    if ((spotKey == wsjtxLastSpotKey) && wsjtxLastSpotDateTime.isValid() &&
+        (wsjtxLastSpotDateTime.secsTo(now) < WSJTX_SPOT_REFRESH_SECONDS))
+        return;
+    wsjtxLastSpotKey = spotKey;
+    wsjtxLastSpotDateTime = now;
+
+    DXSpot spot;
+    spot.clear();
+    spot.setDXCall(_dxCall.toUpper());
+    Frequency freq;
+    freq.fromDouble(_freq, MHz);
+    spot.setFrequency(freq);
+    spot.setMode(_mode);
+    // We heard the DX ourselves, so the local station is the spotter: that
+    // also gives the spot the same-continent bonus it deserves.
+    spot.setSpotter(_spotter.isEmpty() ? stationCallsign : _spotter);
+    spot.setComment("WSJT-X");
+    spot.setDateTime(now);
+    slotDXAssistantNewSpot(spot);
+}
+
 void MainWindow::slotDXAssistantRecalculate()
 {
     // Called after Awards update or ClubLog list refresh
@@ -6413,6 +6454,10 @@ void MainWindow::slotWSJXstatusFromUDPServer(const int _type, const QString &_dx
                 myDataTabWidget->setMyLocator(_de_grid);
 
             myDataTabWidget->setStationCallsign(_de_call.toUpper());
+
+            // The station is now shown in the UI: check it against the DX
+            // Assistant, exactly as KLog does with the DXCluster spots.
+            checkWSJTXSpotWithDXAssistant(_dxcall, _freq, _mode, _de_call);
 
      //TODO: Check what to do with _de_call -> Check if _de_call == station callsign and update if needed.
      //TODO: Check what to do with _de_grid -> Check if _de_grid == My Grid and update if needed.

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -359,6 +359,10 @@ private:
     void initDXAssistant();
     void reconfigureDXAssistantUI(const bool _enabled);  // Adds/removes the DX Assistant tab
     void syncDXAssistantState();   // Pushes the current band and rig state to the widget
+    // A station WSJT-X puts in the UI is a spot like any other: it is turned
+    // into a DXSpot and scored by the very same engine the DXCluster uses.
+    void checkWSJTXSpotWithDXAssistant(const QString &_dxCall, const double _freq,
+                                       const QString &_mode, const QString &_spotter);
     void backupCurrentQSO();
     void restoreCurrentQSO(const bool restoreConfig);
     void showMessageToEnableTheOnlineService(const OnLineProvider _service);
@@ -669,6 +673,11 @@ private:
     QString myContinent;                      // Derived once at startup from the station callsign
     bool dxAssistantEnabled;
     bool clubLogMostWantedEnabled;
+    // WSJT-X repeats its status message about once per second while the same
+    // station is selected: these throttle what reaches the DX Assistant.
+    static constexpr int WSJTX_SPOT_REFRESH_SECONDS = 60;
+    QString wsjtxLastSpotKey;        // Callsign+frequency last fed to the assistant
+    QDateTime wsjtxLastSpotDateTime; // When it was fed, in UTC
     // </DX-ASSISTANT>
 
     // </UI>


### PR DESCRIPTION
A station arriving from the WSJT-X UDP server and shown in the UI is a spot like any other, but until now it went straight into the QSO entry form without ever reaching the DX Assistant: the operator could not see whether the station WSJT-X had just selected was an ATNO, a new band or something already confirmed, and it did not count towards the band summary either.

The status message now builds a DXSpot out of the DX call, the dial frequency and the mode, with the local station as the spotter (we heard the DX ourselves, so it earns the same-continent bonus), and hands it to the same path the DXCluster spots follow: the engine scores it, the raw activity tally counts it and the widget lists it when it is worth working.

WSJT-X repeats its status message about once per second while the same station is selected, so the spot is only handed over when the station or the frequency changes, or once a minute, which keeps the entry from ageing out of the list while WSJT-X is still showing it without flooding the "Most active band" tally.


Claude-Session: https://claude.ai/code/session_01RnKgJLQtmEAZNUhSghPfLs