### PR TITLE
Improve translation handling and deployment documentation

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -5,6 +5,7 @@ TBD - 2.5.4
 - Enhancement: The stations WSJT-X sends to KLog are checked against the DX Assistant just like the DXCluster spots, so they are scored and listed with the rest of the spots.
 - Enhancement: The DX Assistant has a single context menu, reachable from both the spot list and the column header, replacing the two separate menus and the "Clear hidden spots" button (which now gives its space to the spot table). It adds Copy Callsign, a "Follow my band" filter that tracks the band you are working on, Status and DXCC filters, a spotter filter with My continent / My DXCC / ALL, "QSY to this freq" when a radio is connected, Clear all, Show to map and Refresh.
 - Enhancement: KLog can import many ADI files in one single operation by simply selecting them.
+- Bugfix: The Windows package did not include the KLog translation files, so KLog was always shown in English (Closes #1054)
 - Bugfix: Fix BAND_RX export when RX band is empty (TNX YL3GBC)
 - Bugfix: Apply the same BAND_RX guard (skip empty, "0" and same-as-BAND values) to the Club Log real-time upload, which also fixes 2-character RX bands (6m/4m/2m) being dropped.
 - Maintenance: The ADIF file is now always produced by a single serializer (QSO::getADIF); removed the unused per-destination ADIF writers and moved the BAND/BAND_RX "0" check into Adif::getADIFField() so it is enforced in one single place.

--- a/README-DEVEL
+++ b/README-DEVEL
@@ -239,12 +239,15 @@ Here is the list of tests to be done before releasing new software:
 
 9.1 ADDING TRANSLATIONS
 
-To add a new translation add the new language file to the klog.pro file following the sintax:
+To add a new translation, create src/translations/klog_<code>.ts and add it to the
+KLOG_TS_FILES list in src/CMakeLists.txt following the sintax:
 
-TRANSLATIONS = KLog_es.ts \
-    klog_fr.ts
+set(KLOG_TS_FILES
+    translations/klog_ca.ts
+    translations/klog_fr.ts
+)
 
-Being es, fr, the ISO codes naming the language.
+Being ca, fr, the ISO codes naming the language.
 
 After a translation is added, you also need to update the aboutdialog.cpp to include a new Translator line.
 
@@ -255,8 +258,14 @@ Translators should work in the *.ts files.
 9.2 UPDATING TRANSLATIONS
 
 Update translations:
-  Run: lupdate -verbose klog.pro
+  Run: lupdate src/ -no-obsolete -ts src/translations/*.ts
   in the klog directory to update the language files
+
+The build compiles the *.ts files into *.qm (build/src/klog_*.qm). Each package
+then puts them where KLog looks for them (Utilities::getTranslationSearchPaths):
+  Linux  : /usr/share/klog/translations/
+  macOS  : KLog.app/Contents/Resources/translations/
+  Windows: the translations folder next to klog.exe
 
 = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
@@ -265,11 +274,27 @@ Update translations:
 Before deploying, translations should be updated.
 
 
+All the packages are built by the scripts in devscripts/. They build with CMake
+and take care of the deployment (Qt runtime, translations, ...), so there is
+nothing to copy by hand.
+
 9.1 DEPLOYING ON LINUX
+
+    .deb package (CPack):
+        cd devscripts
+        bash debian-stable-create-package.sh     (or raspbian-create-package.sh)
+
+    Source tarball:
+        ./devscripts/package-sources.sh
 
 9.2 DEPLOYING ON macOS
 
-    Build KLog with QTCreator
+    cd devscripts
+    ./macos-create-arm.sh        (or ./macos-create-intel.sh)
+
+    The script builds, checks that the translations are in the bundle, runs
+    macdeployqt6 and produces devscripts/KLog-[VERSION]-arm64.dmg.
+
     If you can't run KLog due to missing libTIFF/LibJPEG/libPNG/libGIF chec this URL:
     https://stackoverflow.com/questions/35509731/dyld-symbol-not-found-cg-jpeg-resync-to-restart
     Try this in the shell:
@@ -279,17 +304,17 @@ Before deploying, translations should be updated.
         $ sudo ln -sf libTIFF.dylib /usr/local/lib/libTIFF.dylib
         $ sudo ln -sf libGIF.dylib /usr/local/lib/libGIF.dylib
 
-    Run the following command from the build directory:
-        mv klog.app KLog.app
-        create new folder in KLog.app/Contents/PlugIns/sqldrivers
-        copy $QT_DIR/plugins/sqldrivers/libqsqlite.dylib to the new folder (/Developer/Applications/Qt/plugins/)
-        create new folder: KLog.app/Contents/MacOs/translations
-        copy the *.qm (translation) files into KLog.app/Contents/MacOS/translations
-        macdeployqt KLog.app/ -dmg
-        mv KLog.dmg KLog-[VERSION].dmg
-
 9.3 DEPLOYING ON WINDOWS
     Currently using an Open Source Licence of: BitRock InstallBuilder
+
+    cd devscripts
+    win64-create-package.bat
+
+    The script builds, stages klog.exe, the OpenSSL and Hamlib DLLs, the Qt
+    runtime (windeployqt6) and the KLog translations into src\release, and then
+    builds the installer from build-win64.xml, which packs src\release.
+    Anything KLog needs at runtime has to be in src\release or it will not
+    reach the installation folder.
 
 9.4 ICON
     Follow this link for all the OS:

--- a/devscripts/debian-stable-create-package.sh
+++ b/devscripts/debian-stable-create-package.sh
@@ -83,6 +83,16 @@ if [ -z "$CPACK_DEB" ]; then
     exit 1
 fi
 
+# --- Check the translations made it into the package ---
+# The .qm files are installed into /usr/share/klog/translations, which is where
+# KLog looks for them. If LinguistTools is missing they are silently skipped,
+# and KLog would be shipped in English only.
+if ! dpkg-deb -c "$CPACK_DEB" | grep -q "share/klog/translations/klog_.*\.qm"; then
+    echo "ERROR: $CPACK_DEB contains no KLog translation files"
+    echo "       Check that Qt6 LinguistTools (lrelease) is available."
+    exit 1
+fi
+
 FINAL_NAME="klog_${KLOG_VERSION}_debian-stable_${ARCH}.deb"
 mv "$CPACK_DEB" "$DEVSCRIPTS_DIR/${FINAL_NAME}"
 

--- a/devscripts/macos-create-arm.sh
+++ b/devscripts/macos-create-arm.sh
@@ -65,6 +65,16 @@ echo "[2/4] Configuring with CMake..."
 echo "[3/4] Building..."
 "$CMAKE_BIN" --build "$PROJECT_DIR/build" -j 4
 
+# --- Check the translations made it into the bundle ---
+# CMake copies build/src/klog_*.qm into Contents/Resources/translations, which is
+# where KLog looks for them. If LinguistTools is missing they are silently
+# skipped, and KLog would be shipped in English only.
+if ! ls "$APP/Contents/Resources/translations"/klog_*.qm >/dev/null 2>&1; then
+    echo "ERROR: No KLog translations in $APP/Contents/Resources/translations"
+    echo "       Check that Qt6 LinguistTools (lrelease) is available."
+    exit 1
+fi
+
 # --- Deploy Qt into the bundle and create DMG ---
 echo "[4/4] Deploying Qt and creating DMG..."
 

--- a/devscripts/macos-create-intel.sh
+++ b/devscripts/macos-create-intel.sh
@@ -63,12 +63,21 @@ echo "[2/4] Configuring with CMake..."
 echo "[3/4] Building..."
 "$CMAKE_BIN" --build "$PROJECT_DIR/build" -j 2
 
-# --- Deploy Qt into the bundle and create DMG ---
-echo "[4/4] Deploying Qt and creating DMG..."
-# Add after the version detection block
+# --- Bundle name must match OUTPUT_NAME set in src/CMakeLists.txt ---
 APP_NAME="KLog"
 APP="$PROJECT_DIR/build/bin/${APP_NAME}.app"
 
+# --- Check the translations made it into the bundle ---
+# CMake copies build/src/klog_*.qm into Contents/Resources/translations, which is
+# where KLog looks for them. If LinguistTools is missing they are silently
+# skipped, and KLog would be shipped in English only.
+if ! ls "$APP/Contents/Resources/translations"/klog_*.qm >/dev/null 2>&1; then
+    echo "ERROR: No KLog translations in $APP/Contents/Resources/translations"
+    echo "       Check that Qt6 LinguistTools (lrelease) is available."
+    exit 1
+fi
+
+# --- Deploy Qt into the bundle and create DMG ---
 echo "[4/4] Deploying Qt and creating DMG..."
 
 "$QT_DIR/bin/macdeployqt6" "$APP" \

--- a/devscripts/raspbian-create-package.sh
+++ b/devscripts/raspbian-create-package.sh
@@ -83,6 +83,16 @@ if [ -z "$CPACK_DEB" ]; then
     exit 1
 fi
 
+# --- Check the translations made it into the package ---
+# The .qm files are installed into /usr/share/klog/translations, which is where
+# KLog looks for them. If LinguistTools is missing they are silently skipped,
+# and KLog would be shipped in English only.
+if ! dpkg-deb -c "$CPACK_DEB" | grep -q "share/klog/translations/klog_.*\.qm"; then
+    echo "ERROR: $CPACK_DEB contains no KLog translation files"
+    echo "       Check that Qt6 LinguistTools (lrelease) is available."
+    exit 1
+fi
+
 FINAL_NAME="klog_${KLOG_VERSION}_raspberrypi_${ARCH}.deb"
 mv "$CPACK_DEB" "$DEVSCRIPTS_DIR/${FINAL_NAME}"
 

--- a/devscripts/win64-create-package.bat
+++ b/devscripts/win64-create-package.bat
@@ -101,6 +101,19 @@ if %errorlevel% neq 0 (
     exit /b 1
 )
 
+rem --- Deploy the KLog translations ---
+rem :: qt_add_translations compiles the .ts files into build\src\klog_*.qm.
+rem :: windeployqt6 only deploys the Qt translations (qt_*.qm), so the KLog ones
+rem :: have to be copied by hand into the translations folder next to klog.exe,
+rem :: which is where KLog looks for them (Utilities::getTranslationSearchPaths).
+echo Deploying KLog translations...
+if not exist src\release\translations mkdir src\release\translations
+copy /Y build\src\klog_*.qm src\release\translations\
+if %errorlevel% neq 0 (
+    echo ERROR: No KLog translation files ^(klog_*.qm^) found in build\src
+    exit /b 1
+)
+
 rem --- [4/4] Build installer ---
 echo [4/4] Building installer package...
 cd devscripts

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -368,8 +368,12 @@ endif()
 if(APPLE)
     install(TARGETS klog BUNDLE DESTINATION .)
     set_source_files_properties(${KLOG_DOC} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
-    set_source_files_properties(${QM_FILES} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/translations)
-    target_sources(klog PRIVATE ${QM_FILES})
+    # The .qm files travel inside the bundle, in Contents/Resources/translations,
+    # which is where Utilities::getTranslationSearchPaths() looks for them.
+    if(QM_FILES)
+        set_source_files_properties(${QM_FILES} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/translations)
+        target_sources(klog PRIVATE ${QM_FILES})
+    endif()
     set_target_properties(klog PROPERTIES
            # OUTPUT_NAME controls the .app bundle name visible in the DMG and Finder.
            # Without this the bundle inherits the target name "klog" (lowercase).
@@ -391,7 +395,11 @@ elseif(WIN32)
        RUNTIME DESTINATION .
    )
    install(FILES ${KLOG_DOC} DESTINATION .)
-   install(FILES ${QM_FILES} DESTINATION translations)
+   # Guarded like the Linux branch: without LinguistTools QM_FILES is empty and
+   # install(FILES) with no file is a configuration error.
+   if(QM_FILES)
+       install(FILES ${QM_FILES} DESTINATION translations)
+   endif()
 else()
    # =========================================================================
     # Linux / Unix install — FHS + Debian Policy compliant

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,13 +134,18 @@ void loadTranslations(QApplication &app, QTranslator &myappTranslator)
         }
     }
 
+    // Name the folder KLog expects, so the user knows where to drop the file.
+    const QString translationsDir = searchPaths.isEmpty()
+                                        ? QString()
+                                        : QDir::toNativeSeparators(QDir(searchPaths.first()).absolutePath());
+
     QMessageBox::warning(nullptr,
                          "KLog",
                          QString("No translation files for your language were found. "
                                  "KLog will be shown in English.\n"
                                  "If you have the %1 file for your language, "
-                                 "copy it to the translations folder and restart KLog.")
-                             .arg(fileName));
+                                 "copy it to the %2 folder and restart KLog.")
+                             .arg(fileName, translationsDir));
 }
 
 


### PR DESCRIPTION
## Summary
This PR improves translation file handling across the build system and deployment scripts, adds validation checks to ensure translations are properly included in packages, and updates documentation to reflect the CMake-based build system.

## Key Changes

**Documentation Updates (README-DEVEL):**
- Updated translation addition instructions to reference CMake (`src/CMakeLists.txt`) instead of the old `klog.pro` file
- Updated `lupdate` command to use modern syntax: `lupdate src/ -no-obsolete -ts src/translations/*.ts`
- Added detailed deployment instructions for all platforms (Linux, macOS, Windows) with specific script commands
- Documented translation search paths for each platform
- Clarified that deployment scripts handle all packaging details automatically

**Build System (src/CMakeLists.txt):**
- Added guards around `QM_FILES` installation on macOS and Windows to prevent configuration errors when LinguistTools is unavailable
- Added explanatory comments about where translation files are placed in bundles and how KLog locates them

**Deployment Scripts:**
- **macos-create-arm.sh & macos-create-intel.sh**: Added validation to verify translation files (`.qm`) are present in the bundle before creating the DMG, with helpful error messages if LinguistTools is missing
- **debian-stable-create-package.sh & raspbian-create-package.sh**: Added validation to verify translation files are included in the `.deb` package
- **win64-create-package.bat**: Added explicit deployment of KLog translation files to `src\release\translations\` since `windeployqt6` only handles Qt translations

**User-Facing (src/main.cpp):**
- Enhanced the "no translations found" warning message to display the actual folder path where users should place translation files, making it more helpful for end users

## Notable Implementation Details
- Translation validation is performed after build/packaging to catch missing LinguistTools early
- All deployment scripts now explicitly handle KLog translations separately from Qt translations
- The changes maintain backward compatibility while improving robustness against missing optional dependencies

https://claude.ai/code/session_01FBCdQTiAav2gQNU88zw5B8