### PR TITLE
Hide a whole selection of spots from the top of the menu

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -6,6 +6,7 @@ TBD - 2.6
 - New feature: The sources feeding the DX Assistant, DXCluster and WSJT-X, can be enabled and disabled independently in Setup, in the DXCluster page.
 - New feature: The DX Assistant has a Source column showing where each spot came from, and the context menu can filter the list by source.
 - New feature: A "My call" option in the Spotter filter of the DX Assistant shows only the spots your own station reported, the ones you heard yourself.
+- Enhancement: Several spots can be selected in the DX Assistant and hidden in one go. Hiding now opens the context menu, above Copy Callsign, and reads "Hide these spots" when more than one is selected.
 - Enhancement: When the DX Assistant already holds a station on a band and the same station is reported again, the entry only changes hands if the new spotter is closer to you (other continent, your continent, your DXCC, yourself). Otherwise only its age is refreshed, so the spotter, the comment and the source of the best report are no longer overwritten by a more distant one.
 - Enhancement: A decoded WSJT-X line spots both stations: the one transmitting, with your own callsign as the spotter because you heard it yourself, and the one being called, with the transmitting station as its spotter.
 - Enhancement: The UDP server can join a multicast group, so it can share the WSJT-X datagrams with other programs like JTAlert or GridTracker. The group is set in Setup, in the UDP page.

--- a/src/dxcluster/dxclusterassistant.cpp
+++ b/src/dxcluster/dxclusterassistant.cpp
@@ -599,7 +599,9 @@ bool DXClusterAssistant::createUI()
     tableView->setSortingEnabled(true);
     tableView->sortByColumn(DXAssistantSpotModel::ColScore, Qt::DescendingOrder);
     tableView->setSelectionBehavior(QAbstractItemView::SelectRows);
-    tableView->setSelectionMode(QAbstractItemView::SingleSelection);
+    // Several spots can be picked at once, so a batch of them can be hidden
+    // in one go rather than one right-click at a time.
+    tableView->setSelectionMode(QAbstractItemView::ExtendedSelection);
     tableView->setEditTriggers(QAbstractItemView::NoEditTriggers);
     tableView->setContextMenuPolicy(Qt::CustomContextMenu);
     tableView->verticalHeader()->setVisible(false);
@@ -951,10 +953,38 @@ void DXClusterAssistant::slotDoubleClicked(const QModelIndex &_index)
 
 void DXClusterAssistant::slotTableContextMenu(const QPoint &_pos)
 {
+    const QModelIndex clicked = tableView->indexAt(_pos);
+    // Right-clicking outside the selection works on the row under the cursor,
+    // as everywhere else: the menu must never act on rows the user cannot see
+    // it is about to act on.
+    if (clicked.isValid() && (tableView->selectionModel() != nullptr)
+        && !tableView->selectionModel()->isRowSelected(clicked.row(), clicked.parent()))
+    {
+        tableView->selectionModel()->select(clicked,
+                                            QItemSelectionModel::ClearAndSelect |
+                                            QItemSelectionModel::Rows);
+        tableView->setCurrentIndex(clicked);
+    }
+
     DXSpot spot;
-    bool hasSpot = spotForProxyIndex(tableView->indexAt(_pos), spot);
+    bool hasSpot = spotForProxyIndex(clicked, spot);
     showContextMenu(tableView->viewport()->mapToGlobal(_pos),
                     tableView->columnAt(_pos.x()), spot, hasSpot);
+}
+
+QList<DXSpot> DXClusterAssistant::selectedSpots() const
+{
+    QList<DXSpot> spots;
+    if ((tableView == nullptr) || (tableView->selectionModel() == nullptr))
+        return spots;
+
+    for (const QModelIndex &index : tableView->selectionModel()->selectedRows())
+    {
+        DXSpot spot;
+        if (spotForProxyIndex(index, spot))
+            spots.append(spot);
+    }
+    return spots;
 }
 
 void DXClusterAssistant::slotHeaderContextMenu(const QPoint &_pos)
@@ -1002,7 +1032,19 @@ void DXClusterAssistant::showContextMenu(const QPoint &_globalPos, int _column,
 
     QMenu menu(this);
 
-    // 1 - Copy Callsign: the one action worth reaching without a submenu
+    // 1 - Hiding spots is what the operator does most often, so it opens the
+    // menu. It works on the whole selection: several spots can be picked and
+    // dropped from the list in one go.
+    const QList<DXSpot> selection = selectedSpots();
+    const bool severalSpots = (selection.count() > 1);
+    QAction *hideAct = menu.addAction(severalSpots ? tr("Hide these spots")
+                                                   : tr("Hide this spot"));
+    hideAct->setToolTip(severalSpots
+                        ? tr("Hide these callsigns for the rest of the session.")
+                        : tr("Hide this callsign for the rest of the session."));
+    hideAct->setEnabled(_hasSpot);
+
+    // 2 - Copy Callsign: the other action worth reaching without a submenu
     QAction *copyCallAct = menu.addAction(tr("Copy Callsign"));
     copyCallAct->setToolTip(tr("Copy the DX callsign of this spot to the clipboard."));
     copyCallAct->setEnabled(_hasSpot);
@@ -1181,9 +1223,6 @@ void DXClusterAssistant::showContextMenu(const QPoint &_globalPos, int _column,
         qsyAct->setToolTip(tr("Tune the radio to the frequency of this spot."));
     }
 
-    QAction *hideAct = spotMenu->addAction(tr("Hide this spot"));
-    hideAct->setToolTip(tr("Hide this callsign for the rest of the session."));
-
     QAction *qrzAct = spotMenu->addAction(tr("Look up on QRZ.com"));
     qrzAct->setToolTip(tr("Open this callsign's page on QRZ.com."));
 
@@ -1207,7 +1246,16 @@ void DXClusterAssistant::showContextMenu(const QPoint &_globalPos, int _column,
 
     DXSpot spot(_spot);
 
-    if (chosen == copyCallAct)
+    if (chosen == hideAct)
+    {
+        QStringList calls;
+        for (DXSpot selected : selection)
+            calls.append(selected.getDxCall());
+        if (calls.isEmpty())
+            calls.append(spot.getDxCall());   // Nothing selected: the one clicked
+        hideSpotCalls(calls);
+    }
+    else if (chosen == copyCallAct)
     {
         QGuiApplication::clipboard()->setText(spot.getDxCall());
     }
@@ -1306,8 +1354,6 @@ void DXClusterAssistant::showContextMenu(const QPoint &_globalPos, int _column,
             emit spotLogDirectly(spot);
         else if ((qsyAct != nullptr) && (chosen == qsyAct))
             emit spotQSY(spot);
-        else if (chosen == hideAct)
-            hideSpotCall(spot.getDxCall());
         else if (chosen == qrzAct)
             QDesktopServices::openUrl(QUrl(QStringLiteral("https://www.qrz.com/db/") + spot.getDxCall()));
     }
@@ -1372,9 +1418,24 @@ bool DXClusterAssistant::spotIsShown(DXSpot _spot) const
 
 void DXClusterAssistant::hideSpotCall(const QString &_call)
 {
-    if (_call.isEmpty())
+    hideSpotCalls(QStringList(_call));
+}
+
+void DXClusterAssistant::hideSpotCalls(const QStringList &_calls)
+{
+    // A batch of spots is hidden in one go: the view is only rebuilt once,
+    // however many of them the user picked.
+    bool hidden = false;
+    for (const QString &call : _calls)
+    {
+        if (call.isEmpty())
+            continue;
+        hiddenCalls.insert(call);
+        hidden = true;
+    }
+    if (!hidden)
         return;
-    hiddenCalls.insert(_call);
+
     if (proxy != nullptr)
         proxy->invalidate();
     updateBandSummary();

--- a/src/dxcluster/dxclusterassistant.h
+++ b/src/dxcluster/dxclusterassistant.h
@@ -249,6 +249,8 @@ private:
     void showContextMenu(const QPoint &_globalPos, int _column,
                          const DXSpot &_spot, bool _hasSpot);
     void hideSpotCall(const QString &_call);
+    void hideSpotCalls(const QStringList &_calls);   // Hides a whole selection at once
+    QList<DXSpot> selectedSpots() const;   // The spots the user has picked in the table
     bool spotForProxyIndex(const QModelIndex &_index, DXSpot &_spot) const;
     void enforceMaxSpots();           // Evict the lowest-value spots over the cap
     void pruneBandActivity();         // Drop raw-activity entries past the age limit

--- a/tests/tst_dxclusterassistant/tst_dxclusterassistant.cpp
+++ b/tests/tst_dxclusterassistant/tst_dxclusterassistant.cpp
@@ -76,6 +76,8 @@ private slots:
 
     // View filters
     void test_HiddenCallFiltersRow();
+    void test_HideSeveralCallsAtOnce();
+    void test_SeveralSpotsCanBeSelected();
     void test_BandFilterHidesRows();
     void test_ContinentFilterHidesRows();
     void test_SpotterMyDXCCFilterHidesRows();
@@ -430,6 +432,49 @@ void tst_DXClusterAssistant::test_HiddenCallFiltersRow()
     widget->hideSpotCall("EA1AAA");
     QCOMPARE(visibleRows(), 1);
     QCOMPARE(widget->model->spotCount(), 2);   // Still managed, just not shown
+}
+
+void tst_DXClusterAssistant::test_HideSeveralCallsAtOnce()
+{
+    addScored("EA1AAA", band20, 1100);
+    addScored("EA2BBB", band20, 800);
+    addScored("EA3CCC", band40, 500);
+    QCOMPARE(visibleRows(), 3);
+
+    widget->hideSpotCalls(QStringList() << "EA1AAA" << "EA3CCC");
+    QCOMPARE(visibleRows(), 1);
+    QCOMPARE(widget->model->spotCount(), 3);   // Still managed, just not shown
+
+    // An empty callsign in the batch is simply skipped
+    widget->hideSpotCalls(QStringList() << QString() << "EA2BBB");
+    QCOMPARE(visibleRows(), 0);
+
+    widget->clearHiddenSpots();
+    QCOMPARE(visibleRows(), 3);
+}
+
+void tst_DXClusterAssistant::test_SeveralSpotsCanBeSelected()
+{
+    addScored("EA1AAA", band20, 1100);
+    addScored("EA2BBB", band20, 800);
+    addScored("EA3CCC", band40, 500);
+
+    // The table has to allow picking more than one spot for the batch hiding
+    QCOMPARE(widget->tableView->selectionMode(), QAbstractItemView::ExtendedSelection);
+    QCOMPARE(widget->selectedSpots().count(), 0);
+
+    widget->tableView->selectRow(0);
+    widget->tableView->selectionModel()->select(widget->proxy->index(1, 0),
+                                                QItemSelectionModel::Select |
+                                                QItemSelectionModel::Rows);
+    QList<DXSpot> selected = widget->selectedSpots();
+    QCOMPARE(selected.count(), 2);
+
+    QStringList calls;
+    for (DXSpot spot : selected)
+        calls.append(spot.getDxCall());
+    widget->hideSpotCalls(calls);
+    QCOMPARE(visibleRows(), 1);
 }
 
 void tst_DXClusterAssistant::test_BandFilterHidesRows()


### PR DESCRIPTION
Hiding a spot is the entry of the context menu the operator reaches for most often, and it was buried in the Spot submenu, three actions down. It now opens the menu, above Copy Callsign.

It also works on more than one spot at a time: the table takes an extended selection, so a batch of spots can be picked and dropped from the list in one go, and the entry reads "Hide these spots" when more than one is selected. Right-clicking a row outside the selection selects it first, as everywhere else, so the menu never acts on rows the user cannot see it is about to act on. Whatever the size of the batch, the view is rebuilt once.


Claude-Session: https://claude.ai/code/session_01HfxJnJMkaffA5VzHRNK6RF