### PR TITLE
Prevent spots older than TTL from being added to DX Assistant

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -6,6 +6,8 @@ TBD - 2.6
 - New feature: The sources feeding the DX Assistant, DXCluster and WSJT-X, can be enabled and disabled independently in Setup, in the DXCluster page.
 - New feature: The DX Assistant has a Source column showing where each spot came from, and the context menu can filter the list by source.
 - New feature: A "My call" option in the Spotter filter of the DX Assistant shows only the spots your own station reported, the ones you heard yourself.
+- Bugfix: The DX Assistant showed spots older than the configured maximum age, most visibly at startup, when WSJT-X replies to KLog with every decode its band activity window holds. A spot already past that age is no longer added to the list.
+- Bugfix: The decodes coming from WSJT-X were dated with the local date and the UTC time, so west of Greenwich every one of them was filed a day out and shown as hours old.
 - Enhancement: Several spots can be selected in the DX Assistant and hidden in one go. Hiding now opens the context menu, above Copy Callsign, and reads "Hide these spots" when more than one is selected.
 - Enhancement: When the DX Assistant already holds a station on a band and the same station is reported again, the entry only changes hands if the new spotter is closer to you (other continent, your continent, your DXCC, yourself). Otherwise only its age is refreshed, so the spotter, the comment and the source of the best report are no longer overwritten by a more distant one.
 - Enhancement: A decoded WSJT-X line spots both stations: the one transmitting, with your own callsign as the spotter because you heard it yourself, and the one being called, with the transmitting station as its spotter.

--- a/src/dxcluster/dxclusterassistant.cpp
+++ b/src/dxcluster/dxclusterassistant.cpp
@@ -684,6 +684,9 @@ void DXClusterAssistant::addOrUpdateSpot(const DXSpot &_spot)
     if (spot.getScore() < 0)
         return;   // Discarded by the engine (confirmed / unresolvable)
 
+    if (spotIsTooOld(spot))
+        return;   // Already past the age the user allows: never worth showing
+
     if (hiddenCalls.contains(spot.getDxCall()))
         return;   // Hidden this session: silently dropped
 
@@ -714,6 +717,19 @@ void DXClusterAssistant::addOrUpdateSpot(const DXSpot &_spot)
     existing.setDateTime(spot.getDateTime());
     model->replaceSpot(row, existing);
     updateBandSummary();
+}
+
+bool DXClusterAssistant::spotIsTooOld(DXSpot _spot) const
+{
+    // Mirror of DXAssistantSpotModel::removeOlderThan: a spot the very next
+    // TTL sweep would drop has no business entering the list, not even to
+    // refresh an entry already there. WSJT-X in particular replies to the
+    // replay request with everything its band activity window is showing,
+    // which after a few hours of monitoring is mostly history.
+    const QDateTime when = _spot.getDateTime();
+    if (!when.isValid())
+        return false;   // Undated: treated as just arrived, as it always was
+    return when.secsTo(QDateTime::currentDateTimeUtc()) > qint64(ttlMinutes) * 60;
 }
 
 int DXClusterAssistant::spotterProximity(DXSpot _spot) const

--- a/src/dxcluster/dxclusterassistant.h
+++ b/src/dxcluster/dxclusterassistant.h
@@ -255,6 +255,7 @@ private:
     void enforceMaxSpots();           // Evict the lowest-value spots over the cap
     void pruneBandActivity();         // Drop raw-activity entries past the age limit
     bool spotIsShown(DXSpot _spot) const;   // Same rules the proxy filter applies
+    bool spotIsTooOld(DXSpot _spot) const;  // Already past the configured max age
     int spotterProximity(DXSpot _spot) const;   // One of SpotterProximity
     QList<int> dxccsInView() const;   // Entities currently held, sorted by name
 

--- a/src/udpserver.cpp
+++ b/src/udpserver.cpp
@@ -386,11 +386,7 @@ void UDPServer::parse(const QByteArray &msg)
             if (decodedMode.isEmpty())
                 decodedMode = dialMode;
 
-            // WSJT-X only tells the time of the decode: a replay may bring
-            // decodes from just before midnight while it is already past it.
-            QDateTime when = QDateTime(QDate::currentDate(), time, QTimeZone::UTC);
-            if (when > QDateTime::currentDateTimeUtc())
-                when = when.addDays(-1);
+            const QDateTime when = decodeDateTime(time, QDateTime::currentDateTimeUtc());
 
             emit stationDecoded(station.caller, station.remoteStation, decodedFrequency,
                                 decodedMode, snr, station.callingCQ, when);
@@ -541,6 +537,19 @@ void UDPServer::requestReplay()
     out << quint32(0xadbccbda) << clientSchema << quint32(Replay) << clientId;
     socketServer->writeDatagram(datagram, clientAddress, clientPort);
     //qDebug() << Q_FUNC_INFO << " - END";
+}
+
+QDateTime UDPServer::decodeDateTime(const QTime &_time, const QDateTime &_nowUtc)
+{
+    // WSJT-X only tells the time of the decode, in UTC, so the date has to be
+    // the UTC one too: taking the local date would put every decode a day out
+    // west of Greenwich. A replay also brings decodes from just before
+    // midnight while it is already past it, and those belong to the day
+    // before, which is what makes them look like they came from the future.
+    QDateTime when(_nowUtc.date(), _time, QTimeZone::UTC);
+    if (when > _nowUtc)
+        when = when.addDays(-1);
+    return when;
 }
 
 QString UDPServer::modeFromDecodeChar(const QString &_mode)

--- a/src/udpserver.h
+++ b/src/udpserver.h
@@ -108,6 +108,8 @@ private:
     bool startNow(quint16 _port, QHostAddress const& _multicast_group_address);
     void requestReplay();       // Asks WSJT-X to resend the decodes it is showing
     static QString modeFromDecodeChar(const QString &_mode);
+    // When a decode was made, out of the UTC time WSJT-X gives for it
+    static QDateTime decodeDateTime(const QTime &_time, const QDateTime &_nowUtc);
 
     QNetworkInterface networkInterface;
     QUdpSocket *socketServer;

--- a/tests/tst_dxclusterassistant/tst_dxclusterassistant.cpp
+++ b/tests/tst_dxclusterassistant/tst_dxclusterassistant.cpp
@@ -97,6 +97,8 @@ private slots:
     void test_ShownSpotsFollowsTheViewFilters();
 
     // Expiry
+    void test_SpotOlderThanTheTTLIsNeverAdded();
+    void test_OldDuplicateDoesNotRefreshTheAge();
     void test_TTLRemovesOldSpots();
     void test_DefaultTTLIs30Minutes();
 
@@ -807,14 +809,63 @@ void tst_DXClusterAssistant::test_ClearHiddenSpotsRestoresRows()
 // Expiry
 // ─────────────────────────────────────────────────────────────────────────────
 
+void tst_DXClusterAssistant::test_SpotOlderThanTheTTLIsNeverAdded()
+{
+    // WSJT-X answers the replay request with everything its band activity
+    // window is showing, which after a while of monitoring is mostly history:
+    // a spot already past the age the user allows never enters the list.
+    DXSpot ancient = makeSpot("EA1AAA", band20, 1100);
+    ancient.setDateTime(QDateTime::currentDateTimeUtc().addSecs(-60 * 200));
+    widget->addOrUpdateSpot(ancient);
+    QCOMPARE(widget->model->spotCount(), 0);
+
+    // Just inside the age it is still worth showing
+    DXSpot borderline = makeSpot("EA2BBB", band20, 800);
+    borderline.setDateTime(QDateTime::currentDateTimeUtc().addSecs(-60 * 29));
+    widget->addOrUpdateSpot(borderline);
+    QCOMPARE(widget->model->spotCount(), 1);
+
+    // It is the configured age that decides, not a fixed one
+    widget->setTTL(15);
+    QCOMPARE(widget->model->spotCount(), 0);   // The 29 min one is now over it
+
+    DXSpot twentyMinutes = makeSpot("EA3CCC", band20, 500);
+    twentyMinutes.setDateTime(QDateTime::currentDateTimeUtc().addSecs(-60 * 20));
+    widget->addOrUpdateSpot(twentyMinutes);
+    QCOMPARE(widget->model->spotCount(), 0);
+
+    DXSpot tenMinutes = makeSpot("EA4DDD", band20, 500);
+    tenMinutes.setDateTime(QDateTime::currentDateTimeUtc().addSecs(-60 * 10));
+    widget->addOrUpdateSpot(tenMinutes);
+    QCOMPARE(widget->model->spotCount(), 1);
+}
+
+void tst_DXClusterAssistant::test_OldDuplicateDoesNotRefreshTheAge()
+{
+    addScored("EA1AAA", band20, 1100);
+    const QDateTime stored = widget->model->spotAt(0).getDateTime();
+
+    // An over-age report of a station already listed does not touch its age
+    // either, or a replayed decode would age out an entry that is fresh.
+    DXSpot old = makeSpot("EA1AAA", band20, 1100);
+    old.setDateTime(QDateTime::currentDateTimeUtc().addSecs(-60 * 90));
+    widget->addOrUpdateSpot(old);
+
+    QCOMPARE(widget->model->spotCount(), 1);
+    QCOMPARE(widget->model->spotAt(0).getDateTime(), stored);
+}
+
 void tst_DXClusterAssistant::test_TTLRemovesOldSpots()
 {
-    DXSpot fresh = makeSpot("EA1AAA", band20, 1100);
-    DXSpot old   = makeSpot("EA2BBB", band20, 800);
-    old.setDateTime(QDateTime::currentDateTimeUtc().addSecs(-60 * 45));   // 45 min ago
-    widget->addOrUpdateSpot(fresh);
-    widget->addOrUpdateSpot(old);
+    addScored("EA1AAA", band20, 1100);
+    addScored("EA2BBB", band20, 800);
     QCOMPARE(widget->model->spotCount(), 2);
+
+    // Spots over the age can no longer be added, they can only grow old in
+    // the list, so this one is aged where it already sits
+    DXSpot aged = widget->model->spotAt(1);
+    aged.setDateTime(QDateTime::currentDateTimeUtc().addSecs(-60 * 45));   // 45 min ago
+    widget->model->replaceSpot(1, aged);
 
     widget->slotTimerTick();   // TTL is 30 minutes
     QCOMPARE(widget->model->spotCount(), 1);

--- a/tests/tst_udpserver/tst_udpserver.cpp
+++ b/tests/tst_udpserver/tst_udpserver.cpp
@@ -47,6 +47,7 @@ private slots:
     void test_StationFromDecodedTextDXpedition();
     void test_StationFromDecodedTextNotAStation();
     void test_ModeFromDecodeChar();
+    void test_DecodeDateTimeUsesTheUTCDate();
     void test_ParseDecodeDatagram();
     void test_ParseDecodeDatagramWithoutStatus();
     void test_ParseLowConfidenceDecodeDatagram();
@@ -217,6 +218,30 @@ void tst_UDPServer::test_ModeFromDecodeChar()
     QCOMPARE(UDPServer::modeFromDecodeChar("FT8"), QString("FT8"));
 }
 
+void tst_UDPServer::test_DecodeDateTimeUsesTheUTCDate()
+{
+    // Half past midnight UTC, which for an operator west of Greenwich is
+    // still the day before: the date of a decode is the UTC one, or every
+    // one of them would be filed a day out and look hours old.
+    const QDateTime nowUtc(QDate(2026, 3, 15), QTime(0, 30, 0), QTimeZone::UTC);
+
+    QCOMPARE(UDPServer::decodeDateTime(QTime(0, 29, 15), nowUtc),
+             QDateTime(QDate(2026, 3, 15), QTime(0, 29, 15), QTimeZone::UTC));
+
+    // A decode from just before midnight belongs to the day before, and not
+    // to a few minutes into the future
+    QCOMPARE(UDPServer::decodeDateTime(QTime(23, 58, 45), nowUtc),
+             QDateTime(QDate(2026, 3, 14), QTime(23, 58, 45), QTimeZone::UTC));
+
+    // Whatever the time of day, a decode is never in the future and never
+    // older than a day
+    const QDateTime midday(QDate(2026, 3, 15), QTime(12, 0, 0), QTimeZone::UTC);
+    QCOMPARE(UDPServer::decodeDateTime(QTime(11, 59, 0), midday),
+             QDateTime(QDate(2026, 3, 15), QTime(11, 59), QTimeZone::UTC));
+    QCOMPARE(UDPServer::decodeDateTime(QTime(12, 1, 0), midday),
+             QDateTime(QDate(2026, 3, 14), QTime(12, 1), QTimeZone::UTC));
+}
+
 void tst_UDPServer::test_ParseDecodeDatagram()
 {
     UDPServer server;
@@ -235,7 +260,13 @@ void tst_UDPServer::test_ParseDecodeDatagram()
     QCOMPARE(arguments.at(3).toString(), QString("FT8"));
     QCOMPARE(arguments.at(4).toInt(), -12);
     QCOMPARE(arguments.at(5).toBool(), true);
-    QCOMPARE(arguments.at(6).toDateTime().time(), QTime(12, 34, 15));
+    // WSJT-X gives the time of the decode in UTC and nothing else: the date
+    // has to put it in the last 24 hours, wherever the operator is
+    const QDateTime decodedAt = arguments.at(6).toDateTime();
+    const QDateTime nowUtc = QDateTime::currentDateTimeUtc();
+    QCOMPARE(decodedAt.time(), QTime(12, 34, 15));
+    QVERIFY2(decodedAt <= nowUtc, "A decode cannot have been made in the future");
+    QVERIFY2(decodedAt > nowUtc.addDays(-1), "A decode made today cannot be a day old");
 
     // An exchange brings both stations: the one we decoded and the one it is
     // calling, whose callsign we only read out of the message


### PR DESCRIPTION
## Summary
This PR fixes a bug where the DX Assistant would display spots that are already older than the configured maximum age (TTL). This was particularly visible at startup when WSJT-X replies to replay requests with all decodes from its band activity window, which can include very old entries.

## Key Changes

- **DXClusterAssistant**: Added `spotIsTooOld()` method to check if a spot exceeds the configured TTL before adding it to the list. Spots that are already past the age limit are now rejected at entry rather than being added and later removed.

- **DXClusterAssistant**: Modified `addOrUpdateSpot()` to reject spots that fail the TTL age check, preventing old replayed decodes from entering the model.

- **UDPServer**: Extracted decode datetime logic into a new static method `decodeDateTime()` to properly handle UTC date assignment for decodes. This ensures decodes are always dated in UTC (not local time) and never appear to be in the future or older than 24 hours.

- **Tests**: Added comprehensive test coverage:
  - `test_SpotOlderThanTheTTLIsNeverAdded()`: Verifies spots exceeding TTL are rejected at entry
  - `test_OldDuplicateDoesNotRefreshTheAge()`: Ensures duplicate old spots don't refresh the timestamp of existing entries
  - `test_DecodeDateTimeUsesTheUTCDate()`: Validates proper UTC date handling for decodes across timezone boundaries

## Implementation Details

The `spotIsTooOld()` check mirrors the logic in `DXAssistantSpotModel::removeOlderThan()` to ensure consistency. A spot is considered too old if the time elapsed since its timestamp exceeds the configured TTL in minutes. This prevents WSJT-X replay responses from polluting the list with historical data while still allowing undated spots (treated as just arrived) to be added.

https://claude.ai/code/session_01HfxJnJMkaffA5VzHRNK6RF