### PR TITLE
Fix submode persistence in database and QSO handling

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -15,6 +15,7 @@ TBD - 2.6
 - Enhancement: The stations WSJT-X sends to KLog are checked against the DX Assistant just like the DXCluster spots, so they are scored and listed with the rest of the spots.
 - Enhancement: The DX Assistant has a single context menu, reachable from both the spot list and the column header, replacing the two separate menus and the "Clear hidden spots" button (which now gives its space to the spot table). It adds Copy Callsign, a "Follow my band" filter that tracks the band you are working on, Status and DXCC filters, a spotter filter with My continent / My DXCC / ALL, "QSY to this freq" when a radio is connected, Clear all, Show to map and Refresh.
 - Enhancement: KLog can import many ADI files in one single operation by simply selecting them.
+- Bugfix: The submode of a QSO was lost. It was never written to the DB, so a QSO entered as C4FM, USB or FT4 was stored, shown and exported as DIGITALVOICE, SSB or MFSK. The submode is now kept in its own column, the log shows Mode and Submode as separate columns and the ADIF export includes the SUBMODE field again (Closes #1062)
 - Bugfix: The Windows package did not include the KLog translation files, so KLog was always shown in English (Closes #1054)
 - Bugfix: Fix BAND_RX export when RX band is empty (TNX YL3GBC)
 - Bugfix: Apply the same BAND_RX guard (skip empty, "0" and same-as-BAND values) to the Club Log real-time upload, which also fixes 2-character RX bands (6m/4m/2m) being dropped.

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -969,7 +969,7 @@ bool DataBase::updateToLatest()
 /*
  * With the DB updates, the function that is called from here should be also updated.
  * The updateXXX are recursive calls that calls the previous one.
- * Update float DBVersionf = 0.028f; in database.h to the latest version!
+ * Update float DBVersionf = 0.029f; in database.h to the latest version!
  * To rebuild the Mode table and add new modes
  */
     //qDebug() << Q_FUNC_INFO << " - Start";
@@ -980,7 +980,7 @@ bool DataBase::updateToLatest()
         //return false;
     }
     //qDebug() << Q_FUNC_INFO << " - Let's update!";
-    return updateTo028();
+    return updateTo029();
 }
 
 
@@ -2393,18 +2393,18 @@ bool DataBase::updateTableLogs()
 
 bool DataBase::updateModeIdFromSubModeId()
 {// Updates the log with the new mode IDs in each QSO:
-    // STEP-1: Get the modeid and QSOid from the log
-    // STEP-2: uses the modeid to get the name of the mode in the mode table (the old one)
-    // STEP-3: uses the name of the mode in the modetemp table (the new one) to get the new ID
-    // STEP-4: Updates the new ID in the QSO in the log
-    //TODO: Optimize this function
+    // STEP-1: Get the modeid, submode and QSOid from the log
+    // STEP-2: uses those ids to get the names of the mode/submode in the mode table (the old one)
+    // STEP-3: uses those names in the modetemp table (the new one) to get the new IDs
+    // STEP-4: Updates the new IDs in the QSO in the log
+    // Both modeid and submode point to the mode table, so both have to be remapped whenever
+    // that table is rebuilt or they would end up pointing to the wrong mode.
 
     //qDebug() << Q_FUNC_INFO ;
     bool cancel = false;
     bool alreadyCancelled = false;
     QString modetxt = QString();
     QString sq = QString();
-    bool sqlOk2 = false;
     bool sqlOk3 = false;
     int modeFound = -1;
     int id = -1;
@@ -2446,7 +2446,24 @@ bool DataBase::updateModeIdFromSubModeId()
     while (qMode.next())
         modeIDs.insert(qMode.value(0).toString(), qMode.value(1).toInt());
 
-    sqlOk = query.exec("SELECT modeid, id FROM log ORDER BY modeid");                                                   // STEP-1
+    // Old id -> submode name, so STEP-2 is a hash lookup instead of a reverse search
+    QHash<int, QString> oldIdToSubmode;
+    for (auto it = modeIDs.cbegin(); it != modeIDs.cend(); ++it)
+        oldIdToSubmode.insert(it.value(), it.key());
+
+    // Submode name -> new id, so STEP-3 needs no query per QSO
+    QHash<QString, int> newModeIDs;
+    QSqlQuery qNewMode;
+    if (!qNewMode.exec("SELECT submode, id FROM modetemp"))
+    {
+        queryErrorManagement(Q_FUNC_INFO, qNewMode.lastError().databaseText(),
+                             qNewMode.lastError().text(), qNewMode.lastQuery());
+        return false;
+    }
+    while (qNewMode.next())
+        newModeIDs.insert(qNewMode.value(0).toString(), qNewMode.value(1).toInt());
+
+    sqlOk = query.exec("SELECT modeid, id, submode FROM log ORDER BY modeid");                                          // STEP-1
 
     if (sqlOk)
     {
@@ -2468,56 +2485,41 @@ bool DataBase::updateModeIdFromSubModeId()
 
                 modeFound = (query.value(0)).toInt();
                 id = (query.value(1)).toInt();
+                const int oldSubModeId = (query.value(2)).toInt();
                      //qDebug() << Q_FUNC_INFO << ": (STEP-1) modeFound (numb): " << QString::number(modeFound) ;
-                modetxt = modeIDs.key(modeFound);
-                //modetxt = getModeNameFromNumber(modeFound, false);   //TODO: Create a QHash to speed this up                                                   //STEP-2
+                modetxt = oldIdToSubmode.value(modeFound);                                                              // STEP-2
 
                      //qDebug() << Q_FUNC_INFO << ": (STEP-2) mode found (txt): " << modetxt ;
 
-                //TODO The following query can be executed in: getModeIdFromSubMode()
+                // log.submode is remapped together with log.modeid: both are ids of the mode
+                // table and would dangle otherwise. QSOs older than the submode column fall
+                // back to the mode, which is all that was ever stored for them.
+                const QString subModeTxt = oldIdToSubmode.value(oldSubModeId > 0 ? oldSubModeId : modeFound);
 
-                sq = QString("SELECT id FROM modetemp WHERE submode='%1'").arg(modetxt);                                // STEP-3
-                QSqlQuery query2;
-                sqlOk2 = query2.exec(sq);
+                const int newModeId    = newModeIDs.value(modetxt, -1);                                                 // STEP-3
+                const int newSubModeId = newModeIDs.value(subModeTxt, -1);
 
-                if (sqlOk2)
+                if (newModeId > 0)
                 {
-                         //qDebug() << Q_FUNC_INFO << ": (STEP-3) sqlOK2 TRUE" ;
-                    if (query2.next())
-                    {
-                        if (query2.isValid())
-                        {
-                            modeFound = query2.value(0).toInt();
-                            query2.finish();
-                            sq = QString ("UPDATE log SET modeid='%1' WHERE id='%2'").arg(modeFound).arg(id);           // STEP-4
-                            sqlOk3 = execQuery(Q_FUNC_INFO, sq);
+                    if (newSubModeId > 0)
+                        sq = QString ("UPDATE log SET modeid='%1', submode='%2' WHERE id='%3'")                          // STEP-4
+                                 .arg(newModeId).arg(newSubModeId).arg(id);
+                    else
+                        sq = QString ("UPDATE log SET modeid='%1' WHERE id='%2'").arg(newModeId).arg(id);
+                    sqlOk3 = execQuery(Q_FUNC_INFO, sq);
 
-                            if (sqlOk3)
-                            {
-                                //qDebug() << Q_FUNC_INFO << ": (STEP-4) ID: " << QString::number(id) << " updated to: " << QString::number(modeFound) <<"/"<< modetxt ;
-                            }
-                            else
-                            {
-                                // queryErrorManagement(Q_FUNC_INFO, query3.lastError().databaseText(), query3.lastError().nativeErrorCode(), query3.lastQuery());
-                                //qDebug() << Q_FUNC_INFO << ": (STEP-4) ID: " << QString::number(id) << " NOT updated-2"  ;
-                            }
-                        }
-                        else
-                        {
-                            query2.finish();
-                                 //qDebug() << Q_FUNC_INFO << ": (STEP-3) query2 not valid "   ;
-                        }
+                    if (sqlOk3)
+                    {
+                        //qDebug() << Q_FUNC_INFO << ": (STEP-4) ID: " << QString::number(id) << " updated to: " << QString::number(newModeId) <<"/"<< modetxt ;
                     }
                     else
                     {
-                          //qDebug() << Q_FUNC_INFO << ": query2 not next "   ;
+                        //qDebug() << Q_FUNC_INFO << ": (STEP-4) ID: " << QString::number(id) << " NOT updated-2"  ;
                     }
                 }
                 else
                 {
-                    queryErrorManagement(Q_FUNC_INFO, query2.lastError().databaseText(), query2.lastError().nativeErrorCode(), query2.lastQuery());
-                    query2.finish();
-                         //qDebug() << Q_FUNC_INFO << ": ID: " << QString::number(id) << " NOT updated-1"  ;
+                         //qDebug() << Q_FUNC_INFO << ": ID: " << QString::number(id) << " NOT updated-1, mode not found: " << modetxt ;
                 }
             }
 
@@ -4595,6 +4597,39 @@ bool DataBase::updateTo028()
         return false;
 
     return updateDBVersion(softVersion, "0.028");
+}
+
+bool DataBase::updateTo029()
+{
+    // Updates the DB to 0.029:
+    // log.submode was declared but never written, so the submode of every QSO was lost.
+    // Fill it in for the existing QSOs pointing it to the mode row already referenced by
+    // log.modeid. In DBs coming from old KLog versions, modeid may point to a real submode
+    // row (USB, C4FM...) and this recovers that information; in newer ones modeid points to
+    // the parent mode and submode simply becomes equal to the mode, which is all that was
+    // ever stored for those QSOs.
+    // log.submode is declared VARCHAR but holds mode ids, as its foreign key already stated;
+    // SQLite applies numeric affinity when comparing it against mode.id, so the joins work.
+
+    //qDebug() << Q_FUNC_INFO << " latestRead: " << getDBVersion() ;
+
+    latestReaded = getDBVersion();
+    if (latestReaded >= 0.029f)
+    {
+        //qDebug() << Q_FUNC_INFO << " - I am in 029" ;
+        return true;
+    }
+
+    if (!updateTo028())
+        return false;
+
+    // Now I am in the previous version and I can update the DB.
+
+    if (!execQuery(Q_FUNC_INFO, "UPDATE log SET submode = modeid "
+                                "WHERE submode IS NULL OR TRIM(submode) = '' OR submode = '0'"))
+        return false;
+
+    return updateDBVersion(softVersion, "0.029");
 }
 
 int DataBase::getNumberOfQsos(const int _logNumber)

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -44,7 +44,7 @@
 #include "../klogdefinitions.h"
 
 class QSqlRelationalTableModel;
-const float DBVersionf = 0.028f; // This is the latest version of the DB.
+const float DBVersionf = 0.029f; // This is the latest version of the DB.
 
 class DataBase : public QObject
 {
@@ -150,6 +150,7 @@ private:
     bool updateTo026(); // KLog-2.4: Recreates entity to make UTC a real & add new ADIF fields
     bool updateTo027(); // KLog-2.4.2: Recreates entity to make UTC a real & add new ADIF fields
     bool updateTo028(); // KLog-2.4.3: Adds FT2 submode
+    bool updateTo029(); // KLog-2.4.3: Populates log.submode, that was never written
 
     bool updateTableLog(const int _version);
     bool updateDBVersion(QString _softV, QString _dbV);

--- a/src/dataproxy_sqlite.cpp
+++ b/src/dataproxy_sqlite.cpp
@@ -444,6 +444,16 @@ QString DataProxy_SQLite::getNameFromSubMode (const QString &_sm)
     return m_cache.getModeNameFromSubmode(_sm);
 }
 
+int DataProxy_SQLite::getSubModeIdFromQSO(const QSO &_qso)
+{
+    // log.modeid holds the id of the parent mode while log.submode holds the id of the
+    // submode actually worked (C4FM, USB, FT4...). Both point to the mode table, where
+    // every mode also has a row repeating its own name as submode (SSB/SSB, CW/CW...),
+    // so this lookup resolves even when no specific submode is known.
+    const QString subMode = _qso.getSubmode().isEmpty() ? _qso.getMode() : _qso.getSubmode();
+    return getIdFromModeName(subMode);
+}
+
 QList<int> DataProxy_SQLite::getModeGroupIds(const int _modeId)
 {
     // Returns all mode IDs that share the same parent mode as _modeId
@@ -2620,6 +2630,7 @@ QSqlQuery DataProxy_SQLite::getPreparedQuery(const QString &_s, const QSO &_qso)
     query.bindValue(":bandid", getIdFromBandName(_qso.getBand()));
     //query.bindValue(":modeid", _qso.getModeIdFromModeName());
     query.bindValue(":modeid", getIdFromModeName(_qso.getMode()));
+    query.bindValue(":submode", getSubModeIdFromQSO(_qso));
     query.bindValue(":cqz", _qso.getCQZone());
     query.bindValue(":ituz", _qso.getItuZone());
     query.bindValue(":dxcc", _qso.getDXCC());
@@ -2807,7 +2818,6 @@ QSqlQuery DataProxy_SQLite::getPreparedQuery(const QString &_s, const QSO &_qso)
         query.bindValue(":stx", _qso.getStx());
     query.bindValue(":state", _qso.getState());
     query.bindValue(":station_callsign", _qso.getStationCallsign());
-    // query.bindValue(":submode", _qso.getModeIdFromModeName());
 
     query.bindValue(":swl", util.boolToCharToSQLite (_qso.getSwl()));
     if (adif.isValidUKSMG(_qso.getUksmg()))
@@ -2858,6 +2868,7 @@ void DataProxy_SQLite::bindQSOValues(QSqlQuery &query, const QSO &_qso)
     query.bindValue(":bandid", getIdFromBandName(_qso.getBand()));
     //query.bindValue(":modeid", _qso.getModeIdFromModeName());
     query.bindValue(":modeid", getIdFromModeName(_qso.getMode()));
+    query.bindValue(":submode", getSubModeIdFromQSO(_qso));
     query.bindValue(":cqz", _qso.getCQZone());
     query.bindValue(":ituz", _qso.getItuZone());
     query.bindValue(":dxcc", _qso.getDXCC());
@@ -3045,7 +3056,6 @@ void DataProxy_SQLite::bindQSOValues(QSqlQuery &query, const QSO &_qso)
         query.bindValue(":stx", _qso.getStx());
     query.bindValue(":state", _qso.getState());
     query.bindValue(":station_callsign", _qso.getStationCallsign());
-    // query.bindValue(":submode", _qso.getModeIdFromModeName());
 
     query.bindValue(":swl", util.boolToCharToSQLite (_qso.getSwl()));
     if (adif.isValidUKSMG(_qso.getUksmg()))
@@ -3083,15 +3093,18 @@ QSO DataProxy_SQLite::fromDB(const int _qsoId)
     if (_qsoId<1)
         return QSO();
 
+    // The submode is read from log.submode; QSOs logged before that column was populated
+    // fall back to the mode pointed at by log.modeid, which in old DBs may itself be a submode.
     QString queryString = "SELECT log.*, "
                           "t_band.name AS band_name, "
                           "t_band_rx.name AS bandrx_name, "
                           "t_mode.name AS mode_name, "
-                          "t_mode.submode AS submode_name "
+                          "COALESCE(t_submode.submode, t_mode.submode) AS submode_name "
                           "FROM log "
                           "LEFT JOIN band AS t_band ON log.bandid = t_band.id "
                           "LEFT JOIN band AS t_band_rx ON log.band_rx = t_band_rx.id "
                           "LEFT JOIN mode AS t_mode ON log.modeid = t_mode.id "
+                          "LEFT JOIN mode AS t_submode ON log.submode = t_submode.id "
                           "WHERE log.id = :idQSO";
 
 
@@ -8477,12 +8490,14 @@ QString DataProxy_SQLite::getADIFFromQSOQuery(QSqlRecord rec, ExportMode _em, bo
     qso.setFreqRX((aux.toDouble()));
 
     aux = getADIFValueFromRec(rec, "modeid");
-    // qString aux2 = getSubModeFromId(aux.toInt());
+    const int recModeId = aux.toInt();
+    qso.setMode(getSubModeFromId(recModeId));   // setMode derives the parent mode by itself
 
-    qso.setMode(getSubModeFromId(aux.toInt()));
-
+    // The submode is taken from log.submode. QSOs logged before that column was populated
+    // fall back to log.modeid, which in old DBs may itself point to a submode row.
     aux = getADIFValueFromRec(rec, "submode");
-    qso.setSubmode(getSubModeFromId(aux.toInt()));
+    const int recSubModeId = aux.toInt();
+    qso.setSubmode(getSubModeFromId(recSubModeId > 0 ? recSubModeId : recModeId));
 
     qso.setPropMode(getADIFValueFromRec(rec, "prop_mode"));
     qso.setSatName(getADIFValueFromRec(rec, "sat_name"));

--- a/src/dataproxy_sqlite.h
+++ b/src/dataproxy_sqlite.h
@@ -86,6 +86,7 @@ public:
 
     int getIdFromModeName(const QString& _modeName);
     int getIdFromBandName(const QString& _bandName);
+    int getSubModeIdFromQSO(const QSO &_qso);   // mode table id of the submode to store in log.submode
     //int getSubModeIdFromSubMode(const QString &_subModeName);
 
     bool isValidMode(const QString& _modeName);

--- a/src/logmodel.cpp
+++ b/src/logmodel.cpp
@@ -209,9 +209,18 @@ bool LogModel::setColumns(const QStringList &_columns)
         setRelation(nameCol, QSqlRelation("band", "id", "name"));
     }
 
+    // The Mode column shows the parent mode (mode.name) and the Submode column the submode
+    // actually worked (mode.submode), so each one carries its own data. mode.name resolves to
+    // the parent even for old QSOs whose modeid points to a submode row.
     if (_columns.contains("modeid"))
     {
         nameCol = rec.indexOf("modeid");
+        setRelation(nameCol, QSqlRelation("mode", "id", "name"));
+    }
+
+    if (_columns.contains("submode"))
+    {
+        nameCol = rec.indexOf("submode");
         setRelation(nameCol, QSqlRelation("mode", "id", "submode"));
     }
 

--- a/src/qso.cpp
+++ b/src/qso.cpp
@@ -1011,6 +1011,18 @@ bool QSO::setMode(const QString &_c)
     return false;
 }
 
+bool QSO::setModeFromADIF(const QString &_c)
+{
+    // ADIF does not mandate any order between the MODE and SUBMODE fields. If SUBMODE has
+    // already been read, a MODE naming that very group must not overwrite it: a record with
+    // <SUBMODE:4>C4FM before <MODE:12>DIGITALVOICE has to keep C4FM as the submode.
+    // Setting the mode from the UI keeps using setMode(), where picking the parent mode
+    // deliberately clears any previously selected submode.
+    if (haveSubMode && !submode.isEmpty() && (adif->getModeFromSubmode(submode) == _c))
+        return true;
+    return setMode(_c);
+}
+
 QString QSO::getMode() const { return mode; }
 
 bool QSO::setDate(const QDate &_c)
@@ -3352,7 +3364,16 @@ bool QSO::setSubmode(const QString &_c)
 {
     logEvent (Q_FUNC_INFO, "Start", Debug);
     //qDebug() << Q_FUNC_INFO << ": " << _c;
-    return setMode(_c);
+    // Every mode is also a valid submode of itself (SSB/SSB, CW/CW...), so a plain mode
+    // name is accepted here and simply results in mode == submode.
+    if (!adif->isValidSubMode(_c))
+        return false;
+
+    submode = _c;
+    haveSubMode = true;
+    mode = adif->getModeFromSubmode(submode);
+    haveMode = true;
+    return true;
 }
 
 QString QSO::getSubmode() const { return submode; }
@@ -3630,7 +3651,7 @@ void QSO::InitializeHash() {
         {"LOTW_QSL_RCVD", decltype(std::mem_fn(&QSO::decltype_function))(&QSO::setLoTWQSL_RCVD)},
         {"LOTW_QSL_SENT", decltype(std::mem_fn(&QSO::decltype_function))(&QSO::setLoTWQSL_SENT)},
         {"MAX_BURSTS", decltype(std::mem_fn(&QSO::decltype_function))(&QSO::setMaxBursts)},
-        {"MODE", decltype(std::mem_fn(&QSO::decltype_function))(&QSO::setMode)},
+        {"MODE", decltype(std::mem_fn(&QSO::decltype_function))(&QSO::setModeFromADIF)},
         {"MS_SHOWER", decltype(std::mem_fn(&QSO::decltype_function))(&QSO::setMsShower)},
         {"MY_ALTITUDE", decltype(std::mem_fn(&QSO::decltype_function))(&QSO::setMyAltitude)},
         {"MY_ANTENNA", decltype(std::mem_fn(&QSO::decltype_function))(&QSO::setMyAntenna)},

--- a/src/qso.h
+++ b/src/qso.h
@@ -73,6 +73,7 @@ public:
     bool setBand(const QString &_c);
     QString getBand() const;
     bool setMode(const QString &_c);
+    bool setModeFromADIF(const QString &_c);  // As setMode, but keeps an already read SUBMODE
     QString getMode() const;
 
     bool setDateTimeOn(const QDateTime &_c);

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -500,7 +500,7 @@ QStringList Utilities::getDefaultLogFields()
 {
     QStringList fields;
     fields.clear();
-    fields << "qso_date" << "call" << "rst_sent" << "rst_rcvd" << "bandid" << "modeid" << "comment";
+    fields << "qso_date" << "call" << "rst_sent" << "rst_rcvd" << "bandid" << "modeid" << "submode" << "comment";
     return fields;
 }
 

--- a/tests/tst_dataproxy/tst_dataproxy.cpp
+++ b/tests/tst_dataproxy/tst_dataproxy.cpp
@@ -52,6 +52,8 @@ private slots:
     void test_primarySubdivisions();
     void test_qsosCache();
     void test_addQSO();
+    void test_submodeRoundTrip_data();
+    void test_submodeRoundTrip();
     void test_bandClassification_data();
     void test_bandClassification();
 
@@ -317,6 +319,54 @@ void tst_DataProxy::test_addQSO()
 
     int id = dataProxy->addQSO(qso);
     QVERIFY2(id > 0, qPrintable(QString("addQSO returned %1").arg(id)));
+}
+
+void tst_DataProxy::test_submodeRoundTrip_data()
+{
+    QTest::addColumn<QString>("entered");          // What the user picks in the mode combobox
+    QTest::addColumn<QString>("expectedMode");
+    QTest::addColumn<QString>("expectedSubmode");
+    QTest::addColumn<int>("minute");               // Keeps every row a different QSO
+
+    QTest::newRow("C4FM") << "C4FM" << "DIGITALVOICE" << "C4FM" << 1;
+    QTest::newRow("USB")  << "USB"  << "SSB"          << "USB"  << 2;
+    QTest::newRow("LSB")  << "LSB"  << "SSB"          << "LSB"  << 3;
+    QTest::newRow("FT4")  << "FT4"  << "MFSK"         << "FT4"  << 4;
+    QTest::newRow("JT9C") << "JT9C" << "JT9"          << "JT9C" << 5;
+    QTest::newRow("SSB")  << "SSB"  << "SSB"          << "SSB"  << 6;
+    QTest::newRow("CW")   << "CW"   << "CW"           << "CW"   << 7;
+}
+
+void tst_DataProxy::test_submodeRoundTrip()
+{
+    // The submode must survive the trip to the DB and back (issue #1062)
+    QFETCH(QString, entered);
+    QFETCH(QString, expectedMode);
+    QFETCH(QString, expectedSubmode);
+    QFETCH(int, minute);
+
+    QSO qso;
+    qso.clear();
+    qso.setCall("EA4K");
+    qso.setDateTimeOn(QDateTime(QDate(2024, 3, 28), QTime(10, minute, 0), QTimeZone::UTC));
+    qso.setBand("10M");
+    qso.setMode(entered);
+    qso.setLogId(1);
+
+    const int id = dataProxy->addQSO(qso);
+    QVERIFY2(id > 0, qPrintable(QString("addQSO returned %1 for %2").arg(id).arg(entered)));
+
+    // The mode goes to log.modeid and the submode to log.submode, each one on its own column.
+    // Every mode has a row repeating its own name as submode, so modeid resolves to the mode.
+    QSqlQuery q;
+    QVERIFY(q.exec(QString("SELECT modeid, submode FROM log WHERE id=%1").arg(id)));
+    QVERIFY(q.next());
+    QCOMPARE(dataProxy->getSubModeFromId(q.value(0).toInt()), expectedMode);
+    QCOMPARE(dataProxy->getSubModeFromId(q.value(1).toInt()), expectedSubmode);
+
+    const QSO stored = dataProxy->fromDB(id);
+    QCOMPARE(stored.getMode(), expectedMode);
+    QCOMPARE(stored.getSubmode(), expectedSubmode);
 }
 
 void tst_DataProxy::test_bandClassification_data()

--- a/tests/tst_qso/tst_qso.cpp
+++ b/tests/tst_qso/tst_qso.cpp
@@ -317,11 +317,46 @@ void tst_QSO::test_Constructor()
 
 void  tst_QSO::test_ModeManagement()
 {
+    qso->clear();
     qso->setMode("FM");
     qso->setSubmode("FM");
-    //qDebug() << Q_FUNC_INFO << "Mode: " << qso->getMode();
-    //qDebug() << Q_FUNC_INFO << "Submode: " << qso->getSubmode();
-    //qDebug() << Q_FUNC_INFO << qso->getModeIdFromModeName();
+    QCOMPARE(qso->getMode(), QString("FM"));
+    QCOMPARE(qso->getSubmode(), QString("FM"));
+
+    // A submode keeps its own identity and derives the parent mode
+    qso->clear();
+    QVERIFY(qso->setMode("C4FM"));
+    QCOMPARE(qso->getMode(), QString("DIGITALVOICE"));
+    QCOMPARE(qso->getSubmode(), QString("C4FM"));
+
+    qso->clear();
+    QVERIFY(qso->setSubmode("USB"));
+    QCOMPARE(qso->getMode(), QString("SSB"));
+    QCOMPARE(qso->getSubmode(), QString("USB"));
+
+    // Picking the parent mode in the UI clears the previously selected submode
+    qso->clear();
+    QVERIFY(qso->setMode("USB"));
+    QVERIFY(qso->setMode("SSB"));
+    QCOMPARE(qso->getMode(), QString("SSB"));
+    QCOMPARE(qso->getSubmode(), QString("SSB"));
+
+    // ADIF does not fix the order of MODE and SUBMODE: a MODE naming the group of the
+    // submode already read must not overwrite it
+    qso->clear();
+    QVERIFY(qso->setSubmode("C4FM"));
+    QVERIFY(qso->setModeFromADIF("DIGITALVOICE"));
+    QCOMPARE(qso->getMode(), QString("DIGITALVOICE"));
+    QCOMPARE(qso->getSubmode(), QString("C4FM"));
+
+    // ... but a MODE of another group does replace it
+    QVERIFY(qso->setModeFromADIF("CW"));
+    QCOMPARE(qso->getMode(), QString("CW"));
+    QCOMPARE(qso->getSubmode(), QString("CW"));
+
+    // Unknown modes are rejected
+    QVERIFY(!qso->setMode("NOTAMODE"));
+    QVERIFY(!qso->setSubmode("NOTAMODE"));
 }
 
 


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where the `log.submode` column was declared but never populated, causing submode information (USB, C4FM, FT4, etc.) to be lost when QSOs were saved to the database. The changes ensure submodes are properly stored and retrieved, and handle backward compatibility with existing databases.

## Key Changes

- **Database Migration (v0.028 → v0.029)**: Added `updateTo029()` function that populates the previously empty `log.submode` column by copying from `log.modeid` for existing QSOs, preserving submode information from older database versions.

- **Optimized Mode ID Remapping**: Refactored `updateModeIdFromSubModeId()` to use hash tables instead of per-QSO database queries, significantly improving performance when rebuilding the mode table. Now handles both `modeid` and `submode` columns together since both reference the mode table.

- **QSO Submode Handling**: 
  - Implemented `setModeFromADIF()` to respect ADIF field ordering—if SUBMODE is read before MODE, a parent mode field won't overwrite an already-selected submode
  - Modified `setSubmode()` to properly set the submode independently while deriving the parent mode
  - Added `getSubModeIdFromQSO()` helper to resolve submode IDs, falling back to mode ID for QSOs without explicit submodes

- **Database Queries**: Updated `fromDB()` to use `COALESCE()` when reading submodes, falling back to `log.modeid` for QSOs logged before the submode column was populated.

- **UI Updates**: 
  - Modified LogModel to properly display mode and submode columns with correct foreign key relations
  - Updated default log fields to include the submode column
  - Added comprehensive test coverage for submode round-trip persistence

## Implementation Details

- Both `log.modeid` and `log.submode` point to the mode table; the mode table includes rows where a mode repeats itself as its own submode (SSB/SSB, CW/CW, etc.)
- Backward compatibility is maintained: old QSOs without explicit submodes fall back to their mode ID
- The submode column is VARCHAR but holds numeric IDs; SQLite's numeric affinity handles comparisons correctly

https://claude.ai/code/session_01DdvzKNUVyssyFSdEfQKjoZ