### PR TITLE
ci: fix invalid job schema in SAST workflow

### DIFF
--- a/.github/workflows/sast.yaml
+++ b/.github/workflows/sast.yaml
@@ -18,11 +18,11 @@ on:
 # Set the Job #
 ###############
 jobs:
-  permissions:
+  build:
+    permissions:
       actions: read-all
       contents: read
 
-  build:
     # Name the Job
     name: SAST
 


### PR DESCRIPTION
## Summary
- `.github/workflows/sast.yaml` has never actually run: the original indentation put `permissions:` and `build:` at mismatched indentation levels under `jobs:`, which isn't valid YAML and fails to parse.
- PR #1066 tidied the whitespace in that block, which made the file parse, but left `permissions` as a sibling of `build` under `jobs:` — GitHub Actions then reads that as a job literally named `permissions` with no `runs-on`/`steps`, which is still an invalid job definition. The workflow still can't run.
- This PR nests `permissions` inside the `build` job, which is the valid place for job-scoped permissions, so the SAST workflow can actually execute.

## Test plan
- [x] Parsed the resulting YAML and confirmed `jobs.build` now has both `permissions` and `runs-on` (previously `permissions` had neither `runs-on` nor `steps`, and would fail workflow validation)
- [ ] Confirm the `SAST` check now appears and runs on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_0199kY3z9xw2SeQpBTKySmvy)_