### PR TITLE
Scroll log view to top after ADIF/LoTW import so new QSOs are visible

### DIFF
--- a/src/logwindow.cpp
+++ b/src/logwindow.cpp
@@ -302,6 +302,12 @@ void LogWindow::refresh()
   //qDebug() << Q_FUNC_INFO << " - END";
 }
 
+void LogWindow::scrollToTop()
+{
+    if (logModel->rowCount() > 0)
+        logView->setCurrentIndex(logModel->index(0, 0));
+}
+
 void LogWindow::createActions()
 {
     //qDebug() << Q_FUNC_INFO << " - Start";

--- a/src/logwindow.h
+++ b/src/logwindow.h
@@ -52,6 +52,7 @@ public:
     void createlogPanel(const int _currentLog);
     void clear();
     void refresh();
+    void scrollToTop();
     void setCurrentLog(const int _currentLog);
 
     void qslSentViaBureau(const int _qsoId);    //Maybe this could be defined as private and call it with an action, if needed.

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2868,6 +2868,7 @@ void MainWindow::slotLoTWDownloadedFileProcess(const QString &_fn)
         msgBox.setInformativeText(aux);
         msgBox.exec();
         logWindow->refresh();
+        logWindow->scrollToTop();
         dxccStatusWidget->refresh();
         //TODO: Add the QSOs to the widget and show showAdifImportWidget->show();
     }
@@ -4934,6 +4935,7 @@ void MainWindow::slotADIFImport(){
     {
         updateQSLRecAndSent();
         logWindow->refresh();
+        logWindow->scrollToTop();
        //qDebug() << Q_FUNC_INFO << " -3";
         m_adifImporting = true;
         checkIfNewBandOrMode();


### PR DESCRIPTION
## Summary
- After an ADIF or LoTW import commits its transaction, `logWindow->refresh()` re-fetches rows sorted by `qso_date DESC`, but the `QTableView` keeps its previous scroll position. If the user was scrolled away from the top, the newly imported QSOs land above the viewport and look "missing" until they scroll up manually.
- Adds `LogWindow::scrollToTop()`, which moves the current index to `logModel->index(0, 0)`, and calls it right after `refresh()` in `slotADIFImport()` (single- and multi-file import) and `slotLoTWDownloadedFileProcess()`.
- Other `refresh()` call sites (single-QSO save, export operations) are left unchanged so the user's scroll position isn't disrupted there.

Closes #1006

## Test plan
- [ ] Import an ADIF file while scrolled away from the top of the log view and confirm the newly imported QSOs are visible without manual scrolling.
- [ ] Repeat with a multi-file ADIF import.
- [ ] Download and process a LoTW file and confirm the same behavior.
- [ ] Confirm scroll position is unaffected by single-QSO save and export operations.


---
_Generated by [Claude Code](https://claude.ai/code/session_016meM2MSFtjaxhSAfGiSQzH)_