### PR TITLE
Clean up old build artifacts before uploading to NAS

### DIFF
--- a/devscripts/jenkins/Jenkinsfile.debian-stable
+++ b/devscripts/jenkins/Jenkinsfile.debian-stable
@@ -141,6 +141,11 @@ pipeline {
                     string(credentialsId: 'nas-password', variable: 'NAS_PASS')
                 ]) {
                     sh '''
+                        # Remove older Debian stable packages first; smbclient put never
+                        # overwrites/removes files of other versions on its own.
+                        smbclient //"$NAS_HOST"/Local \
+                            -U "$NAS_USER"%"$NAS_PASS" \
+                            -c "del Subir/klog_*_debian-stable_${ARCH}.deb" || true
                         smbclient //"$NAS_HOST"/Local \
                             -U "$NAS_USER"%"$NAS_PASS" \
                             -c "put devscripts/${DEB_NAME} Subir/${DEB_NAME}"

--- a/devscripts/jenkins/Jenkinsfile.macos-arm
+++ b/devscripts/jenkins/Jenkinsfile.macos-arm
@@ -84,6 +84,11 @@ pipeline {
                     string(credentialsId: 'nas-password', variable: 'NAS_PASS')
                 ]) {
                     sh '''
+                        # Remove older arm64 DMGs first; smbclient put never
+                        # overwrites/removes files of other versions on its own.
+                        smbclient //"$NAS_HOST"/Local \
+                            -U "$NAS_USER"%"$NAS_PASS" \
+                            -c "del Subir/${APP_NAME}-*-arm64.dmg" || true
                         smbclient //"$NAS_HOST"/Local \
                             -U "$NAS_USER"%"$NAS_PASS" \
                             -c "put devscripts/${DMG_NAME} Subir/${DMG_NAME}"

--- a/devscripts/jenkins/Jenkinsfile.macos-intel
+++ b/devscripts/jenkins/Jenkinsfile.macos-intel
@@ -86,6 +86,11 @@ pipeline {
                     string(credentialsId: 'nas-password', variable: 'NAS_PASS')
                 ]) {
                     sh '''
+                        # Remove older intel DMGs first; smbclient put never
+                        # overwrites/removes files of other versions on its own.
+                        smbclient //"$NAS_HOST"/Local \
+                            -U "$NAS_USER"%"$NAS_PASS" \
+                            -c "del Subir/${APP_NAME}-*-intel.dmg" || true
                         smbclient //"$NAS_HOST"/Local \
                             -U "$NAS_USER"%"$NAS_PASS" \
                             -c "put devscripts/${DMG_NAME} Subir/${DMG_NAME}"

--- a/devscripts/jenkins/Jenkinsfile.raspbian
+++ b/devscripts/jenkins/Jenkinsfile.raspbian
@@ -87,6 +87,11 @@ pipeline {
                     string(credentialsId: 'nas-password', variable: 'NAS_PASS')
                 ]) {
                     sh '''
+                        # Remove older Raspbian packages first; smbclient put never
+                        # overwrites/removes files of other versions on its own.
+                        smbclient //"$NAS_HOST"/Local \
+                            -U "$NAS_USER"%"$NAS_PASS" \
+                            -c "del Subir/${APP_NAME}_*_raspberrypi_${ARCH}.deb" || true
                         smbclient //"$NAS_HOST"/Local \
                             -U "$NAS_USER"%"$NAS_PASS" \
                             -c "put devscripts/${DEB_NAME} Subir/${DEB_NAME}"

--- a/devscripts/jenkins/Jenkinsfile.sources
+++ b/devscripts/jenkins/Jenkinsfile.sources
@@ -81,6 +81,11 @@ pipeline {
                     string(credentialsId: 'nas-password', variable: 'NAS_PASS')
                 ]) {
                     sh '''
+                        # Remove older source tarballs first; smbclient put never
+                        # overwrites/removes files of other versions on its own.
+                        smbclient //"$NAS_HOST"/Local \
+                            -U "$NAS_USER"%"$NAS_PASS" \
+                            -c "del Subir/${APP_NAME}-*.tar.gz" || true
                         smbclient //"$NAS_HOST"/Local \
                             -U "$NAS_USER"%"$NAS_PASS" \
                             -c "put ${ARCHIVE_NAME} Subir/${ARCHIVE_NAME}"

--- a/devscripts/jenkins/Jenkinsfile.windows
+++ b/devscripts/jenkins/Jenkinsfile.windows
@@ -130,6 +130,11 @@ pipeline {
                     string(credentialsId: 'nas-password', variable: 'NAS_PASS')
                 ]) {
                     sh '''
+                        # Remove older win64 installers first; smbclient put never
+                        # overwrites/removes files of other versions on its own.
+                        smbclient //"$NAS_HOST"/Local \
+                            -U "$NAS_USER"%"$NAS_PASS" \
+                            -c "del Subir/*win64*.exe" || true
                         for f in devscripts/*win64*.exe; do
                             fname=$(basename "$f")
                             smbclient //"$NAS_HOST"/Local \


### PR DESCRIPTION
## Summary
This change adds cleanup steps to all build pipeline Jenkinsfiles to remove older build artifacts from the NAS before uploading new ones. This prevents accumulation of outdated packages and installers on the shared storage.

## Key Changes
- **Debian stable pipeline**: Delete old `klog_*_debian-stable_${ARCH}.deb` files before uploading new packages
- **macOS ARM pipeline**: Delete old `${APP_NAME}-*-arm64.dmg` files before uploading new DMGs
- **macOS Intel pipeline**: Delete old `${APP_NAME}-*-intel.dmg` files before uploading new DMGs
- **Raspbian pipeline**: Delete old `${APP_NAME}_*_raspberrypi_${ARCH}.deb` files before uploading new packages
- **Sources pipeline**: Delete old `${APP_NAME}-*.tar.gz` source tarballs before uploading new ones
- **Windows pipeline**: Delete old `*win64*.exe` installers before uploading new ones

## Implementation Details
Each pipeline now includes a cleanup step that uses `smbclient` to delete matching old artifacts with a wildcard pattern before uploading the new build. The deletion commands use `|| true` to ensure the pipeline continues even if no matching files are found (e.g., on first upload). This addresses the limitation that `smbclient put` does not automatically overwrite or remove files of other versions.

https://claude.ai/code/session_016w6T8HscqCXkUB9ny7HjNS