### PR TITLE
Fix Groovy backslash escaping in Windows Jenkinsfile

### DIFF
--- a/devscripts/jenkins/Jenkinsfile.windows
+++ b/devscripts/jenkins/Jenkinsfile.windows
@@ -106,9 +106,9 @@ pipeline {
             steps {
                 bat '''
                     echo === Installer file ===
-                    dir devscripts\%EXE_NAME%
+                    dir devscripts\\%EXE_NAME%
                     echo === SHA256 checksum ===
-                    powershell -Command "Get-FileHash devscripts\%EXE_NAME% -Algorithm SHA256 | Format-List"
+                    powershell -Command "Get-FileHash devscripts\\%EXE_NAME% -Algorithm SHA256 | Format-List"
                 '''
             }
         }
@@ -118,8 +118,8 @@ pipeline {
             steps {
                 bat '''
                     powershell -Command ^
-                        "(Get-FileHash 'devscripts\%EXE_NAME%' -Algorithm SHA256).Hash + '  devscripts\%EXE_NAME%'" ^
-                        > "devscripts\%EXE_NAME%.sha256"
+                        "(Get-FileHash 'devscripts\\%EXE_NAME%' -Algorithm SHA256).Hash + '  devscripts\\%EXE_NAME%'" ^
+                        > "devscripts\\%EXE_NAME%.sha256"
                 '''
                 archiveArtifacts artifacts: "devscripts/${env.EXE_NAME}, devscripts/${env.EXE_NAME}.sha256",
                                  fingerprint: true


### PR DESCRIPTION
## Summary
- Follow-up to #1074, which merged before this fix was ready and shipped a Groovy compile error to `master`.
- `Jenkinsfile.windows` failed to load in Jenkins with:
  ```
  WorkflowScript: 109: unexpected char: '\' @ line 109, column 35.
                         dir devscripts\%EXE_NAME%
  ```

## Root cause
Groovy still processes backslash escapes inside triple-single-quoted `'''...'''` strings — they aren't raw strings. The pre-existing code already accounted for this (`devscripts\\*win64*.exe`), but #1074 swapped that glob for `%EXE_NAME%` and introduced single backslashes before `%`, which Groovy doesn't recognize as a valid escape sequence.

## Change
Escape the literal path backslashes as `\\` in the `Verify` and `Archive artifacts` stages' `bat` blocks, matching the convention already used elsewhere in the file.

## Test plan
- [x] Verified against the Jenkins job on this branch — build now parses and runs successfully.


---
_Generated by [Claude Code](https://claude.ai/code/session_016w6T8HscqCXkUB9ny7HjNS)_