### PR TITLE
Fix FT2 and FT4 display in log mode column

### DIFF
--- a/src/logmodel.cpp
+++ b/src/logmodel.cpp
@@ -65,6 +65,26 @@ QVariant LogModel::data(const QModelIndex &index, int role) const
     if (role != Qt::DisplayRole)
         return QSqlRelationalTableModel::data(index, role);
 
+    // Display the submode actually worked in the visible Mode column.
+    const QSqlRecord schema = QSqlDatabase::database().record("log");
+    if (index.column() == schema.indexOf("modeid"))
+    {
+        const int submodeColumn = schema.indexOf("submode");
+        if (submodeColumn >= 0)
+        {
+            const QVariant raw = QSqlRelationalTableModel::data(
+                this->index(index.row(), submodeColumn), role);
+            if (relation(submodeColumn).isValid() && !raw.toString().isEmpty())
+                return raw;
+
+            bool ok = false;
+            const int submodeId = raw.toInt(&ok);
+            const QString name = ok ? dataProxy->getSubModeFromId(submodeId) : QString();
+            if (!name.isEmpty())
+                return name;
+        }
+    }
+
     QString columnName = this->record().fieldName(index.column());
     if (columnName == "band_rx")
     {


### PR DESCRIPTION
## Summary

- Display FT2 and FT4 in the visible Mode column instead of only the parent MFSK mode.
- Fall back to the parent mode when no valid submode exists.
- Keep the database and ADIF representation unchanged: MODE=MFSK with SUBMODE=FT2 or SUBMODE=FT4.

## Validation

- KLog built successfully from official master with Qt 6.12.
- Verified that WJ2D on 21.141125 MHz displays FT4 instead of MFSK.
- Existing FT8 rows remain unchanged.
- git diff --check completed without errors.