### PR TITLE
Fix DMG volume name leaking build machine paths

### DIFF
--- a/devscripts/macos-create-arm.sh
+++ b/devscripts/macos-create-arm.sh
@@ -78,10 +78,18 @@ fi
 # --- Deploy Qt into the bundle and create DMG ---
 echo "[4/4] Deploying Qt and creating DMG..."
 
-"$QT_DIR/bin/macdeployqt6" "$APP" \
-    -qmldir="$PROJECT_DIR/src/qml" \
-	-codesign="-" \
-    -dmg
+# Run from build/bin and pass a relative app name: macdeployqt derives the
+# DMG volume name (shown as the Finder window title when the DMG is opened)
+# from the path it's invoked with, so an absolute path leaks the build
+# machine's directory (e.g. the Jenkins workspace) into that title.
+# https://bugreports.qt.io/browse/QTBUG-60324
+(
+    cd "$PROJECT_DIR/build/bin"
+    "$QT_DIR/bin/macdeployqt6" "${APP_NAME}.app" \
+        -qmldir="$PROJECT_DIR/src/qml" \
+        -codesign="-" \
+        -dmg
+)
 
 # macdeployqt6 names the DMG after the .app: KLog.dmg
 mv "$PROJECT_DIR/build/bin/${APP_NAME}.dmg" "$DEVSCRIPTS_DIR/KLog-$KLOG_VERSION-arm64.dmg"

--- a/devscripts/macos-create-intel.sh
+++ b/devscripts/macos-create-intel.sh
@@ -80,10 +80,18 @@ fi
 # --- Deploy Qt into the bundle and create DMG ---
 echo "[4/4] Deploying Qt and creating DMG..."
 
-"$QT_DIR/bin/macdeployqt6" "$APP" \
-    -qmldir="$PROJECT_DIR/src/qml" \
-    -codesign="-" \
-    -dmg
+# Run from build/bin and pass a relative app name: macdeployqt derives the
+# DMG volume name (shown as the Finder window title when the DMG is opened)
+# from the path it's invoked with, so an absolute path leaks the build
+# machine's directory (e.g. the Jenkins workspace) into that title.
+# https://bugreports.qt.io/browse/QTBUG-60324
+(
+    cd "$PROJECT_DIR/build/bin"
+    "$QT_DIR/bin/macdeployqt6" "${APP_NAME}.app" \
+        -qmldir="$PROJECT_DIR/src/qml" \
+        -codesign="-" \
+        -dmg
+)
 
 mv "$PROJECT_DIR/build/bin/${APP_NAME}.dmg" "$DEVSCRIPTS_DIR/KLog-$KLOG_VERSION-intel.dmg"
 


### PR DESCRIPTION
## Summary
Modified macOS build scripts to prevent absolute build paths from leaking into DMG volume names by running `macdeployqt6` from the build directory with relative app paths.

## Changes
- Updated both `macos-create-arm.sh` and `macos-create-intel.sh` to change directory into `$PROJECT_DIR/build/bin` before invoking `macdeployqt6`
- Changed the app argument from absolute path `"$APP"` to relative path `"${APP_NAME}.app"`
- Wrapped the `macdeployqt6` invocation in a subshell to isolate the directory change

## Details
The `macdeployqt6` tool derives the DMG volume name (displayed as the Finder window title) from the path it's invoked with. When called with an absolute path, this leaks the build machine's directory structure (e.g., Jenkins workspace paths) into the DMG metadata. By running from the build directory with a relative path, the volume name is derived from just the app name, preventing sensitive build environment information from being embedded in the final artifact.

This addresses Qt bug report QTBUG-60324.

https://claude.ai/code/session_01HDeMzaJRhVYcFGbjX2erPe