### PR TITLE
Fix memory leaks throughout the application

### DIFF
--- a/src/awardswidget.cpp
+++ b/src/awardswidget.cpp
@@ -53,7 +53,8 @@ AwardsWidget::AwardsWidget(DataProxy_SQLite *dp, World *injectedWorld, QWidget *
     yearlyLabelN = new QLabel();
     yearlyScoreLabelN = new QLabel();
 
-    recalculateAwardsButton = new QPushButton;
+    // recalculateAwardsButton is created in createUI(), where it gets its text
+    // and its parent. Allocating it here as well would just leak that object.
     includeModeForNeededCheckBox = new QCheckBox;
     dataProxy = dp;
     world = injectedWorld;

--- a/src/charts/statscqzperyearbarchartwidget.cpp
+++ b/src/charts/statscqzperyearbarchartwidget.cpp
@@ -115,5 +115,12 @@ void StatsCQZPerYearBarChartWidget::prepareChart(const int _log)
     //chart->createDefaultAxes();
     //series->attachAxis(axis);
     chart->addAxis(axis, Qt::AlignBottom);
-    chartView->setChart (chart);
+    // QChartView::setChart() takes ownership of the new chart but only
+    // *releases* the previous one, it does not delete it. Without this the
+    // whole chart (series, axes and sets) leaks on every refresh, and the
+    // chart is rebuilt every time the user changes the statistic or the log.
+    QChart *previousChart = chartView->chart();
+    chartView->setChart(chart);
+    if (previousChart != nullptr)
+        previousChart->deleteLater();
 }

--- a/src/charts/statsentitiesperyearbarchartwidget.cpp
+++ b/src/charts/statsentitiesperyearbarchartwidget.cpp
@@ -117,5 +117,12 @@ void StatsEntitiesPerYearBarChartWidget::prepareChart(const int _log)
     //chart->createDefaultAxes();
     //series->attachAxis(axis);
     chart->addAxis(axis, Qt::AlignBottom);
-    chartView->setChart (chart);
+    // QChartView::setChart() takes ownership of the new chart but only
+    // *releases* the previous one, it does not delete it. Without this the
+    // whole chart (series, axes and sets) leaks on every refresh, and the
+    // chart is rebuilt every time the user changes the statistic or the log.
+    QChart *previousChart = chartView->chart();
+    chartView->setChart(chart);
+    if (previousChart != nullptr)
+        previousChart->deleteLater();
 }

--- a/src/charts/statsgridsonsatswidget.cpp
+++ b/src/charts/statsgridsonsatswidget.cpp
@@ -173,7 +173,6 @@ void StatsGridsOnSatsWidget::prepareChart(const int _log)
 
         numberLabel->setText(QString::number(number));
     }
-    qDeleteAll(_qsos);
     tableWidget->sortItems(4, Qt::AscendingOrder);
     qDeleteAll(_qsos);
     _qsos.clear();

--- a/src/charts/statsqsosperbandbarchartwidget.cpp
+++ b/src/charts/statsqsosperbandbarchartwidget.cpp
@@ -113,5 +113,12 @@ void StatsQSOsPerBandBarChartWidget::prepareChart(const int _log)
     //chart->createDefaultAxes();
     //series->attachAxis(axis);
     chart->addAxis(axis, Qt::AlignBottom);
-    chartView->setChart (chart);
+    // QChartView::setChart() takes ownership of the new chart but only
+    // *releases* the previous one, it does not delete it. Without this the
+    // whole chart (series, axes and sets) leaks on every refresh, and the
+    // chart is rebuilt every time the user changes the statistic or the log.
+    QChart *previousChart = chartView->chart();
+    chartView->setChart(chart);
+    if (previousChart != nullptr)
+        previousChart->deleteLater();
 }

--- a/src/charts/statsqsospercontinentbarchartwidget.cpp
+++ b/src/charts/statsqsospercontinentbarchartwidget.cpp
@@ -118,5 +118,12 @@ void StatsQSOsPerContinentBarChartWidget::prepareChart(const int _log)
     //chart->createDefaultAxes();
     //series->attachAxis(axis);
     chart->addAxis(axis, Qt::AlignBottom);
-    chartView->setChart (chart);
+    // QChartView::setChart() takes ownership of the new chart but only
+    // *releases* the previous one, it does not delete it. Without this the
+    // whole chart (series, axes and sets) leaks on every refresh, and the
+    // chart is rebuilt every time the user changes the statistic or the log.
+    QChart *previousChart = chartView->chart();
+    chartView->setChart(chart);
+    if (previousChart != nullptr)
+        previousChart->deleteLater();
 }

--- a/src/charts/statsqsosperdxccbarchartwidget.cpp
+++ b/src/charts/statsqsosperdxccbarchartwidget.cpp
@@ -181,5 +181,12 @@ void StatsQSOsPerDXCCBarChartWidget::prepareChart(const int _log)
     //chart->createDefaultAxes();
     //series->attachAxis(axis);
     chart->addAxis(axis, Qt::AlignBottom);
-    chartView->setChart (chart);
+    // QChartView::setChart() takes ownership of the new chart but only
+    // *releases* the previous one, it does not delete it. Without this the
+    // whole chart (series, axes and sets) leaks on every refresh, and the
+    // chart is rebuilt every time the user changes the statistic or the log.
+    QChart *previousChart = chartView->chart();
+    chartView->setChart(chart);
+    if (previousChart != nullptr)
+        previousChart->deleteLater();
 }

--- a/src/charts/statsqsosperhourbarchartwidget.cpp
+++ b/src/charts/statsqsosperhourbarchartwidget.cpp
@@ -121,7 +121,14 @@ void StatsQSOsPerHourBarChartWidget::prepareChart(const int _log)
     //chart->createDefaultAxes();
     //series->attachAxis(axis);
     chart->addAxis(axis, Qt::AlignBottom);
-    chartView->setChart (chart);
+    // QChartView::setChart() takes ownership of the new chart but only
+    // *releases* the previous one, it does not delete it. Without this the
+    // whole chart (series, axes and sets) leaks on every refresh, and the
+    // chart is rebuilt every time the user changes the statistic or the log.
+    QChart *previousChart = chartView->chart();
+    chartView->setChart(chart);
+    if (previousChart != nullptr)
+        previousChart->deleteLater();
 }
 
 

--- a/src/charts/statsqsospermodebarchartwidget.cpp
+++ b/src/charts/statsqsospermodebarchartwidget.cpp
@@ -122,5 +122,12 @@ void StatsQSOsPerModeBarChartWidget::prepareChart(const int _log)
     //chart->createDefaultAxes();
     //series->attachAxis(axis);
     chart->addAxis(axis, Qt::AlignBottom);
-    chartView->setChart (chart);
+    // QChartView::setChart() takes ownership of the new chart but only
+    // *releases* the previous one, it does not delete it. Without this the
+    // whole chart (series, axes and sets) leaks on every refresh, and the
+    // chart is rebuilt every time the user changes the statistic or the log.
+    QChart *previousChart = chartView->chart();
+    chartView->setChart(chart);
+    if (previousChart != nullptr)
+        previousChart->deleteLater();
 }

--- a/src/charts/statsqsospermonthbarchartwidget.cpp
+++ b/src/charts/statsqsospermonthbarchartwidget.cpp
@@ -118,5 +118,12 @@ void StatsQSOsPerMonthBarChartWidget::prepareChart(const int _log)
     //chart->createDefaultAxes();
     //series->attachAxis(axis);
     chart->addAxis(axis, Qt::AlignBottom);
-    chartView->setChart (chart);
+    // QChartView::setChart() takes ownership of the new chart but only
+    // *releases* the previous one, it does not delete it. Without this the
+    // whole chart (series, axes and sets) leaks on every refresh, and the
+    // chart is rebuilt every time the user changes the statistic or the log.
+    QChart *previousChart = chartView->chart();
+    chartView->setChart(chart);
+    if (previousChart != nullptr)
+        previousChart->deleteLater();
 }

--- a/src/charts/statsqsosperyearbarchartwidget.cpp
+++ b/src/charts/statsqsosperyearbarchartwidget.cpp
@@ -112,6 +112,13 @@ void StatsQSOsPerYearBarChartWidget::prepareChart(const int _log)
     //chart->createDefaultAxes();
     //series->attachAxis(axis);
     chart->addAxis(axis, Qt::AlignBottom);
-    chartView->setChart (chart);
+    // QChartView::setChart() takes ownership of the new chart but only
+    // *releases* the previous one, it does not delete it. Without this the
+    // whole chart (series, axes and sets) leaks on every refresh, and the
+    // chart is rebuilt every time the user changes the statistic or the log.
+    QChart *previousChart = chartView->chart();
+    chartView->setChart(chart);
+    if (previousChart != nullptr)
+        previousChart->deleteLater();
     //chart->setAxisX(axis, series);
 }

--- a/src/charts/statssentconfirmedpiechartwidget.cpp
+++ b/src/charts/statssentconfirmedpiechartwidget.cpp
@@ -86,5 +86,12 @@ void StatsSentConfirmedPieChartWidget::prepareChart(const int _log)
     chart->legend()->hide();
 
     chartView->setRenderHint(QPainter::Antialiasing);
-    chartView->setChart (chart);
+    // QChartView::setChart() takes ownership of the new chart but only
+    // *releases* the previous one, it does not delete it. Without this the
+    // whole chart (series, axes and sets) leaks on every refresh, and the
+    // chart is rebuilt every time the user changes the statistic or the log.
+    QChart *previousChart = chartView->chart();
+    chartView->setChart(chart);
+    if (previousChart != nullptr)
+        previousChart->deleteLater();
 }

--- a/src/charts/statsworkedconfirmedpiechartwidget.cpp
+++ b/src/charts/statsworkedconfirmedpiechartwidget.cpp
@@ -90,5 +90,12 @@ void StatsWorkedConfirmedPieChartWidget::prepareChart(const int _log)
     chart->legend()->hide();
 
     chartView->setRenderHint(QPainter::Antialiasing);
-    chartView->setChart (chart);
+    // QChartView::setChart() takes ownership of the new chart but only
+    // *releases* the previous one, it does not delete it. Without this the
+    // whole chart (series, axes and sets) leaks on every refresh, and the
+    // chart is rebuilt every time the user changes the statistic or the log.
+    QChart *previousChart = chartView->chart();
+    chartView->setChart(chart);
+    if (previousChart != nullptr)
+        previousChart->deleteLater();
 }

--- a/src/charts/statsworkedsentpiechartwidget.cpp
+++ b/src/charts/statsworkedsentpiechartwidget.cpp
@@ -87,5 +87,12 @@ void StatsWorkedSentPieChartWidget::prepareChart(const int _log)
     chart->legend()->hide();
 
     chartView->setRenderHint(QPainter::Antialiasing);
-    chartView->setChart (chart);
+    // QChartView::setChart() takes ownership of the new chart but only
+    // *releases* the previous one, it does not delete it. Without this the
+    // whole chart (series, axes and sets) leaks on every refresh, and the
+    // chart is rebuilt every time the user changes the statistic or the log.
+    QChart *previousChart = chartView->chart();
+    chartView->setChart(chart);
+    if (previousChart != nullptr)
+        previousChart->deleteLater();
 }

--- a/src/dxccstatuswidget.cpp
+++ b/src/dxccstatuswidget.cpp
@@ -623,8 +623,6 @@ void DXCCStatusWidget::slotItemDoubleClicked(QTableWidgetItem  * item )
     QList<int> qsos;
     qsos.clear();
 
-    QTableWidgetItem * it = new QTableWidgetItem(0);
-
     //qDebug() << Q_FUNC_INFO << ": - Columns: " << QString::number(columns) ;
 
     if (item)
@@ -646,9 +644,6 @@ void DXCCStatusWidget::slotItemDoubleClicked(QTableWidgetItem  * item )
             //qDebug() << Q_FUNC_INFO << ": - column header: " << (dxccView->horizontalHeaderItem(i))->text();
             //entityName = (dxccView->item(row,i))->text() ;
               //qDebug() << Q_FUNC_INFO << ": - item: " ;
-
-            it->setText(dxccView->item(row,i)->text());
-            //qDebug() << Q_FUNC_INFO << ": - column-txt: "  << it->text();
 
             QString band = dxccView->horizontalHeaderItem(i)->text();
             //qDebug() << Q_FUNC_INFO << ": band: " << band;

--- a/src/elog/elogclublog.cpp
+++ b/src/elog/elogclublog.cpp
@@ -68,6 +68,10 @@ eLogClubLog::~eLogClubLog()
     //qDebug()<< Q_FUNC_INFO << " - Result = " << QString::number(result);
 
     const QByteArray sdata = data->readAll();
+    // The finished() signal of QNetworkAccessManager does not hand over a
+    // reply that deletes itself: the answer has been read, so the reply can
+    // go. Done here because this function has several exit points.
+    data->deleteLater();
 
     QString text = QString();
 
@@ -163,6 +167,7 @@ void eLogClubLog::slotFileUploadFinished(QNetworkReply *data)
           //qDebug()<< "eLogClubLog::slotFileUploadFinished - Result = " << QString::number(result);
 
     const QByteArray sdata = data->readAll();
+    data->deleteLater();      // Not deleted by QNetworkAccessManager
 
     QString text;
 

--- a/src/elog/elogqrzlog.cpp
+++ b/src/elog/elogqrzlog.cpp
@@ -159,6 +159,10 @@ void eLogQrzLog::slotManagerLogFinished(QNetworkReply *data)
     //qDebug()<< "eLogQrzLog::slotManagerLogFinished - Result Text = " << text;
     showDebugLog (Q_FUNC_INFO, "Text: " + text);
     emit showMessage(text);
+    // QNetworkAccessManager does not delete the replies it hands to the
+    // finished() slot: without this every upload leaks the reply and the
+    // buffer holding its answer.
+    data->deleteLater();
     showDebugLog (Q_FUNC_INFO, "END");
 }
 
@@ -488,9 +492,11 @@ void eLogQrzLog::slotManagerFinished(QNetworkReply *data)
    //qDebug() << Q_FUNC_INFO << " - 00010";
     if (result == QNetworkReply::NoError)
     {
-        // qXmlStreamReader reader(sdata);
-        reader = new QXmlStreamReader(sdata);
-        parseXMLAnswer(*reader);
+        // The reader lives just as long as the answer it is parsing: kept as a
+        // member and allocated with new, every callsign looked up on QRZ.com
+        // leaked one reader and the copy of the answer it holds.
+        QXmlStreamReader reader(sdata);
+        parseXMLAnswer(reader);
     }
     else
     {
@@ -503,6 +509,8 @@ void eLogQrzLog::slotManagerFinished(QNetworkReply *data)
 
     emit showMessage(text);
     showDebugLog (Q_FUNC_INFO, "Text: " + text);
+    // The reply is ours to dispose of once the answer has been read
+    data->deleteLater();
     showDebugLog (Q_FUNC_INFO, "END");
 }
 

--- a/src/elog/elogqrzlog.h
+++ b/src/elog/elogqrzlog.h
@@ -113,8 +113,6 @@ private:
     bool logged;
     QUrl serviceUrl;
 
-    QXmlStreamReader *reader;
-
     OnlineMessageWidget *onlineMessage;
     //bool useQSOStationCallsign;
 };

--- a/src/elog/eqslutilities.cpp
+++ b/src/elog/eqslutilities.cpp
@@ -81,6 +81,10 @@ void eQSLUtilities::slotQsoUploadFinished(QNetworkReply *data)
     //qDebug()<< Q_FUNC_INFO << " - Result = " << QString::number(result);
 
     const QByteArray sdata = data->readAll();
+    // QNetworkAccessManager keeps no ownership of the replies it emits with
+    // finished(): dropped here, before the several exit points below, so no
+    // upload leaves its reply and its buffer behind.
+    data->deleteLater();
     QString text = QString();
 
     if (result == QNetworkReply::NoError)

--- a/src/elog/lotwutilities.cpp
+++ b/src/elog/lotwutilities.cpp
@@ -467,7 +467,7 @@ void LoTWUtilities::slotDownloadProgress(qint64 bytesRead) {
 void LoTWUtilities::slotReadyRead()
 {
     //qDebug() << Q_FUNC_INFO << ":  " << reply->readLine();
-    if (file)
+    if (file && reply)
     {
         file->write(reply->readAll());
     }
@@ -487,9 +487,12 @@ void LoTWUtilities::slotFinished()
              //delete file;
              //file = nullptr;
          }
-         //reply->deleteLater();
          pDialog->cancel();
          reply->close();
+         // The reply belongs to us, not to the manager, and nothing uses it
+         // once the download has ended
+         reply->deleteLater();
+         reply = nullptr;
          //qDebug() << Q_FUNC_INFO << ":  - END Canceled";
          return;
      }
@@ -535,7 +538,10 @@ void LoTWUtilities::slotFinished()
         if (ret == QMessageBox::Yes)
         {
             url = newUrl;
-            //reply->deleteLater();
+            // startRequest() overwrites the member: the reply that has just
+            // finished has to go first or the redirection leaks it
+            reply->deleteLater();
+            reply = nullptr;
             file->open(QIODevice::WriteOnly); /* Flawfinder: ignore */
             file->resize(0);
             startRequest(url);
@@ -547,6 +553,8 @@ void LoTWUtilities::slotFinished()
     {
         //qDebug() << Q_FUNC_INFO << ": :  " ;
     }
+    reply->deleteLater();
+    reply = nullptr;
     //qDebug() << "LoTWUtilities::slotReadyRead - Going to parse ...";
     parseDownloadedFile(file->fileName());
     //qDebug() << "LoTWUtilities::slotReadyRead - END";
@@ -556,7 +564,8 @@ void LoTWUtilities::slotCancelDownload()
 {
      //qDebug() << Q_FUNC_INFO << ":  - Start";
     downloadAborted = true;
-    reply->abort();
+    if (reply)
+        reply->abort();
      //qDebug() << Q_FUNC_INFO << ":  - END";
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3186,7 +3186,7 @@ void MainWindow::slotHelpAboutAction()
 
     logEvent(Q_FUNC_INFO, "Start", Devel);
     if (!aboutDialog)
-        aboutDialog = new AboutDialog(softwareVersion, pkgVersion);
+        aboutDialog = new AboutDialog(softwareVersion, pkgVersion, this);
     aboutDialog->exec();
     logEvent(Q_FUNC_INFO, "END", Debug);
     //helpAboutDialog->exec();
@@ -5408,7 +5408,13 @@ void MainWindow::slotShowStats()
 {
     logEvent(Q_FUNC_INFO, "Start", Devel);
     if (!statsWidget)
+    {
         statsWidget = new StatisticsWidget(dataProxy);
+        // Parented so it is destroyed with the main window, but kept as a
+        // top level window: without an owner the whole statistics panel (16
+        // chart widgets) was never freed.
+        statsWidget->setParent(this, Qt::Window);
+    }
     statsWidget->show();
     logEvent(Q_FUNC_INFO, "END", Debug);
 }

--- a/src/qml/mapqmlfile.qml
+++ b/src/qml/mapqmlfile.qml
@@ -257,10 +257,36 @@ Rectangle {
 
     //Location { id: mapCenter }
 
+    // marker.qml is the same file for every spot: compiled once and kept,
+    // instead of building a new Component object on every arriving spot.
+    property var markerComponent: null
+
     function addMarker(latitude, longitude, callsign, color, frequencyMHz) {
-        var component = Qt.createComponent("qrc:///qml/marker.qml")
+        // The DXCluster reports an active station again and again for as long
+        // as it is on the air. One pin per station is what the map is meant to
+        // show, so a station already on it is refreshed in place: otherwise a
+        // busy cluster piles up thousands of map items, each holding its own
+        // scene graph, that are only released when they age out.
+        var call = callsign || ""
+        if (call.length > 0) {
+            for (var m = 0; m < root.spotMarkers.length; m++) {
+                var known = root.spotMarkers[m]
+                if (known.item && known.item.text === call) {
+                    known.item.coordinate  = QtPositioning.coordinate(latitude, longitude)
+                    known.item.markerColor = color        || "#FF0000"
+                    known.item.frequency   = frequencyMHz || 0.0
+                    known.addedAt          = Date.now()   // Heard again: expiry restarts
+                    return
+                }
+            }
+        }
+
+        if (root.markerComponent === null)
+            root.markerComponent = Qt.createComponent("qrc:///qml/marker.qml")
+        var component = root.markerComponent
         if (component.status !== Component.Ready) {
             console.warn("addMarker: failed to load marker.qml:", component.errorString())
+            root.markerComponent = null
             return
         }
         var item = component.createObject(map, {

--- a/src/softwareupdate.cpp
+++ b/src/softwareupdate.cpp
@@ -31,6 +31,7 @@ SoftwareUpdate::SoftwareUpdate(const QString &_klogVersion, QWidget *parent) : Q
       //qDebug() << "SoftwareUpdate::SoftwareUpdate(): " << _klogVersion;
     util = new Utilities(Q_FUNC_INFO);
     updateDialog = new SoftwareUpdateDialog(parent);
+    manager = nullptr;
     latestVersion = "0.0";
     repositoryFound = false;
     url = new QUrl;
@@ -95,6 +96,7 @@ void SoftwareUpdate::slotDownloadFinished(QNetworkReply *reply)
     if (url.toString().length()< QString("https://api.github.com/repos/ea4k/klog/releases/latest").length())
     {
         //qDebug() << Q_FUNC_INFO << ": URL too short" ;
+        reply->deleteLater();
         return;
     }
     QVariant redirectionTarget = reply->attribute(QNetworkRequest::RedirectionTargetAttribute);
@@ -278,12 +280,22 @@ void SoftwareUpdate::connectToURL(const QString &_url)
 {
     // This is where the connection takes place.... so first connection may be the main URL but it launches connection after redirections
     //qDebug() << "SoftwareUpdate::connectToURL: " << _url;
-    QNetworkAccessManager *manager = new QNetworkAccessManager(this);
-    manager->get(QNetworkRequest(QUrl(_url)));
+    // One manager for the whole object: a new one per call (and per
+    // redirection) piled up on the parent until KLog was closed.
+    if (manager == nullptr)
+    {
+        manager = new QNetworkAccessManager(this);
+        connect(manager, SIGNAL(finished(QNetworkReply*)),this, SLOT(slotDownloadFinished(QNetworkReply*)));
+    }
+
+    // A single request, the member one: it carries the User-Agent header that
+    // setHeader() prepares. The previous code fired two GETs, one with the URL
+    // but no header and one with the header but no URL, and the reply of the
+    // headerless one was never disposed of.
+    request.setUrl(QUrl(_url));
     QNetworkReply *reply = manager->get(request);
 
     connect(reply, SIGNAL(readyRead()), this, SLOT(slotReadyRead()));
-    connect(manager, SIGNAL(finished(QNetworkReply*)),this, SLOT(slotDownloadFinished(QNetworkReply*)));
     //qDebug() << "SoftwareUpdate::conectToURL - END";
 }
 

--- a/src/softwareupdate.h
+++ b/src/softwareupdate.h
@@ -78,7 +78,7 @@ private:
     int OSVersion;
     QUrl *url;
 
-    // qNetworkAccessManager *manager;
+    QNetworkAccessManager *manager;
     QNetworkRequest request;
 
     SoftwareUpdateDialog *updateDialog;

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -43,10 +43,15 @@ MapWidget::MapWidget(QWidget *parent)
 MapWidget::~MapWidget()
 {
     if (m_quickView || m_quickWidget) {
+        // Drop the QML scene first so its objects are gone before the view
+        // itself is destroyed with the rest of the children.
         if (m_quickView)   m_quickView->setSource(QUrl());
         else               m_quickWidget->setSource(QUrl());
         qmlEngine()->collectGarbage();
-        QCoreApplication::processEvents();
+        // No processEvents() here: this destructor runs while the widget tree
+        // is being torn down (the map window is owned by the main window), and
+        // spinning the event loop at that point delivers events to objects
+        // that are half destroyed.
     }
 }
 

--- a/src/widgets/map/mapwindowwidget.cpp
+++ b/src/widgets/map/mapwindowwidget.cpp
@@ -25,9 +25,13 @@
  *****************************************************************************/
 #include "mapwindowwidget.h"
 
+// Qt::Window keeps the map as a separate window while the parent takes
+// ownership of it: the constructor used to drop the parent altogether, so the
+// map (and with it the QML engine and its scene graph, by far the heaviest
+// object KLog builds) was never destroyed.
 MapWindowWidget::MapWindowWidget(DataProxy_SQLite *dp, QWidget *parent)
+    : QWidget(parent, Qt::Window)
 {
-    Q_UNUSED(parent);
     //qDebug() << Q_FUNC_INFO;
     dataProxy = dp;
     // Initialize colors to safe defaults here so that setColors() calls that


### PR DESCRIPTION
This PR addresses multiple memory leaks across the codebase by ensuring proper cleanup of dynamically allocated objects and Qt framework resources.

## Summary
The application had several categories of memory leaks related to improper resource management:
- Qt network replies not being deleted after use
- QML components and chart widgets not being properly released
- Network managers and XML readers being allocated unnecessarily
- Parent-child relationships not being established for proper cleanup

## Key Changes

**QML Map Widget (`mapqmlfile.qml`)**
- Cache the marker component as a property instead of creating it on every call
- Implement marker deduplication: update existing markers instead of creating duplicates for repeated station reports
- Prevents thousands of map items from accumulating during active DXCluster sessions

**Network Management (`softwareupdate.cpp`, `lotwutilities.cpp`, `elogqrzlog.cpp`, `elogclublog.cpp`, `eqslutilities.cpp`)**
- Reuse a single `QNetworkAccessManager` instead of creating new ones per request
- Explicitly call `deleteLater()` on `QNetworkReply` objects after reading their data
- Fix reply handling in redirect scenarios to prevent leaking intermediate responses
- Add null checks before accessing reply objects

**Chart Widgets (all `stats*barchartwidget.cpp` files)**
- Properly delete previous chart when setting a new one via `QChartView::setChart()`
- `setChart()` only releases but doesn't delete the previous chart, causing leaks on every refresh

**XML Parsing (`elogqrzlog.cpp`)**
- Change `QXmlStreamReader` from heap-allocated member to stack-allocated local variable
- Eliminates one reader allocation and data copy per QRZ.com lookup

**Widget Ownership (`mainwindow.cpp`, `mapwindowwidget.cpp`)**
- Set proper parent for `AboutDialog` and `StatisticsWidget` to ensure cleanup with main window
- Use `Qt::Window` flag for map widget while maintaining parent ownership
- Remove unnecessary `processEvents()` call during widget destruction

**Cleanup (`dxccstatuswidget.cpp`, `awardswidget.cpp`)**
- Remove unused `QTableWidgetItem` allocation
- Remove duplicate button allocation in `AwardsWidget`
- Remove duplicate `qDeleteAll()` call in stats grid widget

**Map Widget Destruction (`mapwidget.cpp`)**
- Improve QML scene cleanup order and remove problematic event loop processing during destruction

https://claude.ai/code/session_01GrngTwpCtDBqedLzupNED9