### PR TITLE
Give Exit the standard Quit shortcut and fix two event filters

### DIFF
--- a/src/inputwidgets/mainwindowinputqso.cpp
+++ b/src/inputwidgets/mainwindowinputqso.cpp
@@ -910,7 +910,6 @@ void MainWindowInputQSO::receiveFocus()
 
 bool MainWindowInputQSO::eventFilter (QObject *object, QEvent *event)
 {
-    Q_UNUSED(object);
    //qDebug() << Q_FUNC_INFO << " - Start";
     if (!(event->type() == QEvent::Paint ))
     {
@@ -932,6 +931,10 @@ bool MainWindowInputQSO::eventFilter (QObject *object, QEvent *event)
             return true;
         }
     }
-    return QWidget::event(event);
+    // An event filter answers "did I swallow this event?". QWidget::event()
+    // does something else entirely: it delivers the event to *this* widget,
+    // whatever object it was really meant for, and hands back whether that
+    // widget accepted it. Everything not handled above is simply let through.
+    return QWidget::eventFilter(object, event);
 }
 

--- a/src/mainqsoentrywidget.cpp
+++ b/src/mainqsoentrywidget.cpp
@@ -1202,7 +1202,6 @@ bool MainQSOEntryWidget::eventFilter(QObject *object, QEvent *event)
 {
     logEvent (Q_FUNC_INFO, "Start", Debug);
    //qDebug()<< Q_FUNC_INFO;
-    Q_UNUSED(object);
     if (!(event->type() == QEvent::Paint ))
     {
           //qDebug() << Q_FUNC_INFO << ": " << QString::number(event->type ());
@@ -1230,7 +1229,11 @@ bool MainQSOEntryWidget::eventFilter(QObject *object, QEvent *event)
         }
     }
     logEvent (Q_FUNC_INFO, "END", Debug);
-    return QWidget::event(event);
+    // An event filter answers "did I swallow this event?". QWidget::event()
+    // does something else entirely: it delivers the event to *this* widget,
+    // whatever object it was really meant for, and hands back whether that
+    // widget accepted it. Everything not handled above is simply let through.
+    return QWidget::eventFilter(object, event);
 }
 
 void MainQSOEntryWidget::setFocusToOK()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2549,7 +2549,16 @@ void MainWindow::createMenusCommon()
     exitAct = new QAction(tr("E&xit"), this);
     fileMenu->addAction(exitAct);
     //exitAct->setMenuRole(QAction::QuitRole);
-    exitAct->setShortcut(Qt::CTRL | Qt::Key_X);
+    // Ctrl+X is the system Cut everywhere, and on macOS Qt::CTRL is the Command
+    // key, so Exit was claiming Cmd+X. Worse, the text of this action gives it
+    // QuitRole by Qt's heuristic, so on macOS it becomes the native "Quit KLog"
+    // entry and that is the shortcut the user sees there.
+    // QKeySequence::Quit is Cmd+Q on macOS and Ctrl+Q on the Unix desktops;
+    // Windows has no standard binding for it, so Ctrl+Q is set explicitly.
+    QKeySequence quitSequence(QKeySequence::Quit);
+    if (quitSequence.isEmpty())
+        quitSequence = QKeySequence(Qt::CTRL | Qt::Key_Q);
+    exitAct->setShortcut(quitSequence);
     //connect(exitAct, SIGNAL(triggered()), this, SLOT(close()));
     connect(exitAct, SIGNAL(triggered()), this, SLOT(slotFileClose()));
 


### PR DESCRIPTION
Two defects found while investigating #1077. Neither is the cause of that crash — that one turned out to reproduce only in development builds, not in the distributed package — but both are real and independent of it.

Branched from `master`, unrelated to #1081.

## Exit was bound to Ctrl+X

`mainwindow.cpp` bound the Exit action to `Qt::CTRL | Qt::Key_X`. Ctrl+X is the system Cut shortcut on all three platforms KLog runs on.

On macOS it is worse than a collision. `Qt::CTRL` is the Command key there, and the text of the action (`E&xit`) earns it `QuitRole` through Qt's text heuristic, so the action *becomes* the native **Quit KLog** entry of the application menu — showing ⌘X where every other Mac application shows ⌘Q.

`QKeySequence::Quit` resolves to ⌘Q on macOS and Ctrl+Q on the Unix desktops. Windows has no standard binding for it and would leave the entry with no shortcut at all, so Ctrl+Q is set explicitly when the standard sequence comes back empty.

```cpp
QKeySequence quitSequence(QKeySequence::Quit);
if (quitSequence.isEmpty())
    quitSequence = QKeySequence(Qt::CTRL | Qt::Key_Q);
exitAct->setShortcut(quitSequence);
```

**Worth a second opinion:** this changes the shortcut on Windows and Linux too, not just macOS. The bug is the same everywhere (Ctrl+X is Cut), so fixing it everywhere is the consistent call, but it does move a shortcut existing users may have in their fingers. Say the word and I will restrict it to macOS.

**Pre-existing, not touched here:** `logwindow.cpp:502` and `logwindow.cpp:507` both bind Ctrl+Q, to `checkQRZCOMFromLogAct` and `checkDXHeatFromLogAct` — they already collide with each other. Both actions only ever go into the stack-allocated context menu built on right-click, so their shortcuts are live only while that popup is open and the practical effect is close to nil. Flagging it because Exit now claims Ctrl+Q as well.

## Two event filters answering the wrong question

`MainQSOEntryWidget::eventFilter()` and `MainWindowInputQSO::eventFilter()` both ended with:

```cpp
return QWidget::event(event);   // wrong
```

An event filter is asked *"did I swallow this event?"*. That call answers a different question altogether: it delivers the event to the filtering widget itself — whatever object it was really addressed to — and reports back whether that widget accepted it. Both now return `QWidget::eventFilter(object, event)`, letting through everything the Tab handling above does not take.

Neither filter is installed today (both `installEventFilter(this)` calls are commented out), so **this changes no behaviour at runtime**. It removes the trap waiting for whoever re-enables them.

## Testing

`mainqsoentrywidget.cpp` and `mainwindowinputqso.cpp` were syntax-checked against Qt Widgets locally and are clean. `mainwindow.cpp` could not be compiled here — Ubuntu noble has no `qt6-location-dev`, so the full project does not configure — and is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrngTwpCtDBqedLzupNED9

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrngTwpCtDBqedLzupNED9)_