### PR TITLE
Sort the Setup > Bands/Mode Modes list alphabetically

### DIFF
--- a/src/setuppages/setuppagebandmode.cpp
+++ b/src/setuppages/setuppagebandmode.cpp
@@ -46,6 +46,11 @@ SetupPageBandMode::SetupPageBandMode(DataProxy_SQLite *dp, QWidget *parent) : QW
     modesLabel->setText(tr("Modes"));
     modesLabel->setAlignment(Qt::AlignCenter);
 
+    // The mode list has 300+ entries (every ADIF mode and submode) inserted in their
+    // raw declaration order, e.g. FT2 and FT4 sit buried inside MFSK's ~17 submodes.
+    // Sorting alphabetically is what makes a specific one findable.
+    modesListWidget->setSortingEnabled(true);
+
     addBands(dataProxy->getBandNames());
     addModes(dataProxy->getModesAndSubmodes());
 


### PR DESCRIPTION
## Summary
- Follow-up to #1083, which added the missing OFDM mode and DYNAMIC/FREEDATA submode from ADIF 3.1.7.
- FT2 and FT4 were reported as visible in the database but missing from the Setup → Bands/Mode "Modes" checklist. Both are already declared in `Adif::setModes()` and reach that checklist via `DataProxy_SQLite::getModesAndSubmodes()`, the same source that populates the DB — so the data was never the problem.
- The checklist has 300+ entries (every ADIF mode and submode) inserted in raw declaration order with no grouping, so FT2/FT4 sit buried inside MFSK's ~17 submodes and are easy to miss when scanning by eye.
- Enables sorting on the Modes `QListWidget` so entries are alphabetical and actually findable.

## Test plan
- [ ] Open Setup → Bands/Mode and confirm the Modes list is now alphabetically sorted, with FT2/FT4 easy to locate under "F".
- [ ] Confirm checking/unchecking modes and saving settings still works as before (sorting only reorders display, not item identity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRFxdqbQGqyLwfLn4arH3x

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRFxdqbQGqyLwfLn4arH3x)_