### PR TITLE
Fix TX frequency reset when band changes via frequency edit

### DIFF
--- a/src/inputwidgets/mainwindowsattab.cpp
+++ b/src/inputwidgets/mainwindowsattab.cpp
@@ -547,13 +547,13 @@ void MainWindowSatTab::slotSatBandTXComboBoxChanged()
 
         double upLink = tmpFreq.toDouble();
         double downLink;
-        if (dataProxy->isThisFreqInBand(tmpBand,dataProxy->getSatelliteUplink(getSatName(),1)), MHz )
+        if (dataProxy->isThisFreqInBand(tmpBand,dataProxy->getSatelliteUplink(getSatName(),1)))
         {
             upLink = (dataProxy->getSatelliteUplink(getSatName(),1)).toDouble();
             downLink = (dataProxy->getSatelliteDownlink(getSatName(),1)).toDouble();
             updateRXFreq(downLink);
         }
-        else if (dataProxy->isThisFreqInBand(tmpBand,dataProxy->getSatelliteUplink(getSatName(),0)), MHz )
+        else if (dataProxy->isThisFreqInBand(tmpBand,dataProxy->getSatelliteUplink(getSatName(),0)))
         {
             upLink = (dataProxy->getSatelliteUplink(getSatName(),0)).toDouble();
             downLink = (dataProxy->getSatelliteDownlink(getSatName(),1)).toDouble();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -260,6 +260,7 @@ void MainWindow::init_variables()
     qrzAutoChanging = false;
     qrzcomResponseValid = false;
     changingBand = false;
+    freqDrivenBandChange = false;
     logEvents = true;
     //Default band/modes
     bands << "10M" << "15M" << "20M" << "40M" << "80M" << "160M";
@@ -986,7 +987,7 @@ void MainWindow::slotBandChanged (const QString &_b)
     currentMode = currentModeShown;
     syncDXAssistantState();   // "Follow my band" tracks the band in use
 
-    if ((!isFRinBand) || (QSOTabWidget->getTXFreq()<=0))
+    if ((!freqDrivenBandChange) && ((!isFRinBand) || (QSOTabWidget->getTXFreq()<=0)))
     {
           //qDebug() << "MainWindow::slotBandChanged: Freq is not in band or empty"  ;
           //qDebug() << "MainWindow::slotBandChanged: Band: " << mainQSOEntryWidget->getBand()  ;
@@ -6228,7 +6229,16 @@ void MainWindow::slotFreqTXChanged(const Frequency  _fr)
     }
 
     if (!changingBand)
+    {
+        // setBand() can re-enter slotBandChanged() synchronously (directly, or via the
+        // satellite tab's band combos). At that point txFreqSpinBox may still hold the
+        // frequency from before this edit, so slotBandChanged must not use it to decide
+        // whether to reset the TX frequency: the correct value is the one being applied
+        // a few lines below, via setTXFreq(_fr).
+        freqDrivenBandChange = true;
         mainQSOEntryWidget->setBand(dataProxy->getBandNameFromFreq(_fr));
+        freqDrivenBandChange = false;
+    }
 
     //qDebug() << Q_FUNC_INFO << " - 10";
     QSOTabWidget->setTXFreq (_fr);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -646,6 +646,9 @@ private:
     bool txFreqBeingChanged,  updatingBands; //rxFreqBeingChanged  // When the freqs is being modified it is defined to true to prevent other automated to change.
     bool txFreqBeingAutoChanged, rxFreqBeingAutoChanged;        // This is defined to true when freq is being changed by the Sat tab to prevent a loop.
     bool changingBand;  // True when the bands are being changed
+    bool freqDrivenBandChange;  // True while slotFreqTXChanged is switching the band as a side effect of a
+                                 // TX frequency edit; tells slotBandChanged not to reset that same TX
+                                 // frequency using its own (still stale at that point) reading of it.
     bool qslingNeeded;
     bool noMoreErrorShown;              // If true, the errors shown in slotQueryErrorManagement will not be shown anymore in that KLog execution
     bool noMoreModeErrorShown;          // If true, the non-valid modes received from WSJT-x will not be showed to the user


### PR DESCRIPTION
## Summary
This PR fixes a bug where the TX frequency would be incorrectly reset when the user edits the TX frequency and the band automatically changes as a side effect.

## Key Changes
- Added `freqDrivenBandChange` flag to track when `slotBandChanged()` is being called as a side effect of a frequency edit in `slotFreqTXChanged()`
- Modified the condition in `slotBandChanged()` to skip TX frequency reset when the band change was triggered by a frequency edit, preventing the use of stale frequency values
- Fixed syntax errors in `mainwindowsattab.cpp` where extra parameters were being passed to `isThisFreqInBand()` calls

## Implementation Details
The core issue was a race condition: when `slotFreqTXChanged()` calls `setBand()` to update the band based on the new frequency, this can synchronously re-enter `slotBandChanged()`. At that point, the TX frequency spinbox still contains the old value, so `slotBandChanged()` would incorrectly use it to decide whether to reset the TX frequency. 

The fix uses the `freqDrivenBandChange` flag to signal that the band change is frequency-driven, allowing `slotBandChanged()` to skip its frequency validation logic and let the correct frequency value be applied by the subsequent `setTXFreq()` call in `slotFreqTXChanged()`.

https://claude.ai/code/session_01KnQDWAUkEBcsfH2ahuU6kC