### PR TITLE
Refresh the awards panel after a LoTW download

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2881,6 +2881,7 @@ void MainWindow::slotLoTWDownloadedFileProcess(const QString &_fn)
         logWindow->refresh();
         logWindow->scrollToTop();
         dxccStatusWidget->refresh();
+        if (awardsWidget) awardsWidget->showAwards();
         //TODO: Add the QSOs to the widget and show showAdifImportWidget->show();
     }
     else


### PR DESCRIPTION
slotLoTWDownloadedFileProcess() refreshes the log window and the DXCC status widget, but not the awards panel, so the DXCC/WAZ/QSO counters keep showing pre-download values until KLog is restarted.

To reproduce: download from LoTW with confirmations pending. The log shows the new confirmations, the awards counters do not.