### PR TITLE
Default to Yes when exporting a callsign KLog considers invalid

### DIFF
--- a/src/dataproxy_sqlite.cpp
+++ b/src/dataproxy_sqlite.cpp
@@ -8828,7 +8828,7 @@ bool DataProxy_SQLite::showInvalidCallMessage(const QString &_call){
     msgBox.setText(aux);
     msgBox.setInformativeText(tr("Exporting wrong calls may create problems in the applications you are potentially importing this logfile to. It may, however, be a good callsign that is wrongly identified by KLog as not valid."));
     msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-    msgBox.setDefaultButton(QMessageBox::No);
+    msgBox.setDefaultButton(QMessageBox::Yes);
     int ret = msgBox.exec();
     switch (ret) {
     case QMessageBox::Yes:


### PR DESCRIPTION
showInvalidCallMessage() asks whether to export a callsign the validator rejected, with No as the default button. Since the dialog itself says the call may well be valid and wrongly flagged, defaulting to No means an accidental Enter or Escape silently drops a real QSO from the export.

The QSO stays in the log and is marked as sent, so nothing looks wrong, but it never reaches LoTW or Club Log. I found this when my log showed one QSO more than the exported ADIF.

Example: 4JT3DJ (Azerbaijan), 35,245 lookups on QRZ, QSL via Club Log
OQRS and the bureau: https://www.qrz.com/db/4JT3DJ

Defaulting to Yes keeps the warning but makes the safe answer the default one.