### PR TITLE
Do not tell the user TQSL succeeded when it may have failed

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4369,9 +4369,12 @@ void MainWindow::fileExportLoTW2(const QString &_call, QList<int> _qsos)
     {
         msgBox.setIcon(QMessageBox::Question);
         msgBox.setWindowTitle(tr("KLog - LoTW"));
-        msgBox.setText(tr("TQSL finished with no error.\n\nDo you want to mark as Sent all the QSOs uploaded to LoTW?") );
+        msgBox.setText(tr("Did TQSL report a successful upload?\n\n"
+            "Answer Yes only if TQSL confirmed the QSOs reached LoTW. TQSL does "
+            "not always report a failed upload back to KLog, so marking the QSOs "
+            "as sent after a failure would hide them from the next upload."));
         msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No );
-        msgBox.setDefaultButton(QMessageBox::Yes);
+        msgBox.setDefaultButton(QMessageBox::No);
         int i = msgBox.exec();
         if (i == QMessageBox::Yes)
         {


### PR DESCRIPTION
When LoTW is unreachable, TQSL shows the error in its own window and still exits with code 0, printing nothing to stdout. KLog then reports 'TQSL finished with no error' and offers to mark the QSOs as sent, with Yes as the default button.

The QSOs then carry lotw_qsl_sent='Y' while LoTW never received them. Nothing looks wrong, and they are excluded from every later upload, so they are silently lost.

Reproduced by pointing lotw.arrl.org at 127.0.0.1: TQSL reported 'Unable to upload - either your Internet connection is down or LoTW is unreachable', and KLog still reported no error.

Since TQSL's result cannot be trusted here, this asks the user what TQSL actually reported and defaults to No.